### PR TITLE
Allow number as source

### DIFF
--- a/FastImage.js
+++ b/FastImage.js
@@ -88,7 +88,7 @@ const FastImageSourcePropType = PropTypes.shape({
 
 FastImage.propTypes = {
   ...View.propTypes,
-  source: FastImageSourcePropType,
+  source: PropTypes.oneOfType([FastImageSourcePropType, PropTypes.number]),
   onLoadStart: PropTypes.func,
   onProgress: PropTypes.func,
   onLoad: PropTypes.func,


### PR DESCRIPTION
Right now the PropType for source is an object of 
```js
PropTypes.shape({
  uri: PropTypes.string,
  headers: PropTypes.objectOf(PropTypes.string),
  priority: PropTypes.oneOf(Object.keys(FastImage.priority)),
})
```

However the library also works with local images which can be passed in as `require('./image.jpg')`. On android the require is resolved as a number.

This PR removes the PropTypes warning by allowing number as one of the PropTypes .

e.g
```jsx
<Fastlane source={require('./image.jpg')} />
```