### PR TITLE
Gracefully deprecate View.propTypes

### DIFF
--- a/FastImage.js
+++ b/FastImage.js
@@ -6,6 +6,7 @@ import {
   requireNativeComponent,
   View,
 } from 'react-native'
+import { ViewPropTypes } from './lib'
 
 const resolveAssetSource = require('react-native/Libraries/Image/resolveAssetSource')
 
@@ -87,7 +88,7 @@ const FastImageSourcePropType = PropTypes.shape({
 })
 
 FastImage.propTypes = {
-  ...View.propTypes,
+  ...ViewPropTypes,
   source: FastImageSourcePropType,
   onLoadStart: PropTypes.func,
   onProgress: PropTypes.func,

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,5 @@
+import { ViewPropTypes as RNViewPropTypes, View } from 'react-native'
+
+const ViewPropTypes = RNViewPropTypes || View.propTypes
+
+export { ViewPropTypes }


### PR DESCRIPTION
React native 0.44 deprecated View.propTypes in favor of `ViewPropTypes`.

This PR *gracefully* deprecates `View.propTypes` by using 
* `ViewPropTypes` on react-native@0.44^
* `View.propTypes` on react-native < @.44