### PR TITLE
Remove override of createJSModules

### DIFF
--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewPackage.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewPackage.java
@@ -18,11 +18,6 @@ public class FastImageViewPackage implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Collections.<ViewManager>singletonList(new FastImageViewManager());
     }


### PR DESCRIPTION
Since of recently in master the unused createJSModules has been removed and ReactPackage's no longer contain the definition of createJSModules. There for it must be removed in order to not yield a compile error. This is breaking change.

facebook/react-native@ce6fb33