### PR TITLE
Image resizing - Fixing resizemode support.

### DIFF
--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
@@ -142,6 +142,7 @@ class FastImageViewManager extends SimpleViewManager<ImageViewWithUrl> implement
         Glide
                 .with(view.getContext())
                 .load(glideUrl)
+                .dontTransform()
                 .priority(priority)
                 .placeholder(TRANSPARENT_DRAWABLE)
                 .listener(LISTENER)


### PR DESCRIPTION
This pull requests fixes resizemode issues for various modes.
What we encountered were various situations where the image would be zoomed in, instead of being covered using `cover`.
This fix makes sure that the scaletype of the`ImageView` is used, without an additional transformation of glide itself.