### PR TITLE
use application context to avoid deallocated view error

### DIFF
--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
@@ -140,7 +140,7 @@ class FastImageViewManager extends SimpleViewManager<ImageViewWithUrl> implement
         eventEmitter.receiveEvent(viewId, REACT_ON_LOAD_START_EVENT, new WritableNativeMap());
 
         Glide
-                .with(view.getContext())
+                .with(view.getContext().getApplicationContext())
                 .load(glideUrl)
                 .priority(priority)
                 .placeholder(TRANSPARENT_DRAWABLE)

--- a/ios/FastImage/FFFastImageView.h
+++ b/ios/FastImage/FFFastImageView.h
@@ -2,7 +2,7 @@
 
 #import <SDWebImage/UIImageView+WebCache.h>
 #import <SDWebImage/SDWebImageDownloader.h>
-#import "FLAnimatedImageView.h"
+#import <FLAnimatedImage/FLAnimatedImageView.h>
 
 #import <React/RCTComponent.h>
 #import <React/RCTResizeMode.h>

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "format": "prettier --write --no-semi --single-quote --trailing-comma all ./FastImage.js ./example/*.js ./server/*.js",
     "test": "yarn run test:pretty && yarn run test:jest",
     "test:jest": "jest *.js",
-    "test:pretty": "prettier-check --write --no-semi --single-quote --trailing-comma all ./FastImage.js ./example/*.js ./server/*.js"
+    "test:pretty": "prettier-check --write --no-semi --single-quote --trailing-comma all ./FastImage.js ./example/*.js ./server/*.js",
+    "postinstall": "git clone https://github.com/rs/SDWebImage.git ios/Vendor/SDWebImage && cd ios/Vendor/SDWebImage && git submodule update --init --recursive && cd ../../.."
   },
   "devDependencies": {
     "babel-jest": "^20.0.3",


### PR DESCRIPTION
When split screen on Android, view can be reconstructed; therefore, using view context here can cause crashes on Android. Using application context avoids accessing context of a deallocated view.