### PR TITLE
[Fix] GIF Support for iOS

### DIFF
--- a/ios/FastImage/FFFastImageView.h
+++ b/ios/FastImage/FFFastImageView.h
@@ -1,8 +1,8 @@
 #import <UIKit/UIKit.h>
 
-#import <SDWebImage/UIImageView+WebCache.h>
+#import <SDWebImage/FLAnimatedImageView.h>
+#import <SDWebImage/FLAnimatedImageView+WebCache.h>
 #import <SDWebImage/SDWebImageDownloader.h>
-#import "FLAnimatedImageView.h"
 
 #import <React/RCTComponent.h>
 #import <React/RCTResizeMode.h>


### PR DESCRIPTION
## Scope

Do not use SDWeb cache directly go trough FLAnimatedImageView Cache First