### PR TITLE
[Fix] Gif support for iOS

### DIFF
--- a/ios/FastImage/FFFastImageView.h
+++ b/ios/FastImage/FFFastImageView.h
@@ -1,8 +1,4 @@
-#import <UIKit/UIKit.h>
-
-#import <SDWebImage/FLAnimatedImageView.h>
 #import <SDWebImage/FLAnimatedImageView+WebCache.h>
-#import <SDWebImage/SDWebImageDownloader.h>
 
 #import <React/RCTComponent.h>
 #import <React/RCTResizeMode.h>
@@ -20,4 +16,3 @@
 @property (nonatomic, strong) FFFastImageSource *source;
 
 @end
-

--- a/ios/FastImage/FFFastImageView.h
+++ b/ios/FastImage/FFFastImageView.h
@@ -1,8 +1,8 @@
 #import <UIKit/UIKit.h>
 
-#import <SDWebImage/UIImageView+WebCache.h>
+#import <SDWebImage/FLAnimatedImageView.h>
+#import <SDWebImage/FLAnimatedImageView+WebCache.h>
 #import <SDWebImage/SDWebImageDownloader.h>
-#import "FLAnimatedImageView.h"
 
 #import <React/RCTComponent.h>
 #import <React/RCTResizeMode.h>

--- a/ios/FastImage/FFFastImageView.m
+++ b/ios/FastImage/FFFastImageView.m
@@ -35,6 +35,7 @@
         // Set priority.
         SDWebImageOptions options = 0;
         options |= SDWebImageRetryFailed;
+        options |= SDWebImageScaleDownLargeImages;
         switch (_source.priority) {
             case FFFPriorityLow:
                 options |= SDWebImageLowPriority;
@@ -90,4 +91,3 @@
 }
 
 @end
-


### PR DESCRIPTION
## Scope

- [x] Use `SDWebImage` `FLAnimatedImage+WebCache` and offload memory.
- [x] ScaleDownImages when possible (Please note this option is ignored for progressive images)

## Notes

Fix for https://github.com/DylanVann/react-native-fast-image/issues/85