### PR TITLE
Android: Use OkHttpClientProvider to allow extending preconfigured clients.

### DIFF
--- a/android/src/main/java/com/dylanvann/fastimage/OkHttpProgressGlideModule.java
+++ b/android/src/main/java/com/dylanvann/fastimage/OkHttpProgressGlideModule.java
@@ -10,6 +10,8 @@ import com.bumptech.glide.integration.okhttp3.OkHttpUrlLoader;
 import com.bumptech.glide.load.model.GlideUrl;
 import com.bumptech.glide.module.GlideModule;
 
+import com.facebook.react.modules.network.OkHttpClientProvider;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;

--- a/android/src/main/java/com/dylanvann/fastimage/OkHttpProgressGlideModule.java
+++ b/android/src/main/java/com/dylanvann/fastimage/OkHttpProgressGlideModule.java
@@ -34,8 +34,9 @@ public class OkHttpProgressGlideModule implements GlideModule {
 
     @Override
     public void registerComponents(Context context, Glide glide) {
-        OkHttpClient client = new OkHttpClient
-                .Builder()
+        OkHttpClient client = OkHttpClientProvider
+                .getOkHttpClient()
+                .newBuilder()
                 .addInterceptor(createInterceptor(new DispatchingProgressListener()))
                 .build();
         glide.register(GlideUrl.class, InputStream.class, new OkHttpUrlLoader.Factory(client));


### PR DESCRIPTION
The usage of `new OkHttpClient.Builder()` makes it impossible to extend a preconfigured client. Therefor `OkHttpClientProvider.Builder().getOkHttpClient().newBuilder()` should be used. 