### PR TITLE
Added resource width and height information to the onFastImageLoad an…

### DIFF
--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
@@ -95,8 +95,13 @@ class FastImageViewManager extends SimpleViewManager<ImageViewWithUrl> implement
             ThemedReactContext context = (ThemedReactContext) view.getContext();
             RCTEventEmitter eventEmitter = context.getJSModule(RCTEventEmitter.class);
             int viewId = view.getId();
-            eventEmitter.receiveEvent(viewId, REACT_ON_LOAD_EVENT, new WritableNativeMap());
-            eventEmitter.receiveEvent(viewId, REACT_ON_LOAD_END_EVENT, new WritableNativeMap());
+
+            WritableMap resourceData = new WritableNativeMap();
+            resourceData.putInt("width", resource.getIntrinsicWidth());
+            resourceData.putInt("height", resource.getIntrinsicHeight());
+            
+            eventEmitter.receiveEvent(viewId, REACT_ON_LOAD_EVENT, resourceData);
+            eventEmitter.receiveEvent(viewId, REACT_ON_LOAD_END_EVENT, resourceData);
             return false;
         }
     };

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "react-test-renderer": "16.0.0"
   },
   "engines": {
-    "node": "9.2.0",
+    "node": ">=8.6.0",
     "yarn": "1.3.2"
   },
   "jest": {


### PR DESCRIPTION
…d onFastImageLoadEnd events

Instead of an empty map, it may be useful to have some information about the newly loaded resource. 
Since a user doesn't know the dimensions of a remote resource at load time, providing the dimensions on load end allows the user to adjust the view accordingly if required.