### PR TITLE
Added resource width and height information to the onFastImageLoad an…

### DIFF
--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
@@ -95,8 +95,13 @@ class FastImageViewManager extends SimpleViewManager<ImageViewWithUrl> implement
             ThemedReactContext context = (ThemedReactContext) view.getContext();
             RCTEventEmitter eventEmitter = context.getJSModule(RCTEventEmitter.class);
             int viewId = view.getId();
-            eventEmitter.receiveEvent(viewId, REACT_ON_LOAD_EVENT, new WritableNativeMap());
-            eventEmitter.receiveEvent(viewId, REACT_ON_LOAD_END_EVENT, new WritableNativeMap());
+
+            WritableMap resourceData = new WritableNativeMap();
+            resourceData.putInt("width", resource.getIntrinsicWidth());
+            resourceData.putInt("height", resource.getIntrinsicHeight());
+            
+            eventEmitter.receiveEvent(viewId, REACT_ON_LOAD_EVENT, resourceData);
+            eventEmitter.receiveEvent(viewId, REACT_ON_LOAD_END_EVENT, resourceData);
             return false;
         }
     };

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
@@ -95,16 +95,20 @@ class FastImageViewManager extends SimpleViewManager<ImageViewWithUrl> implement
             ThemedReactContext context = (ThemedReactContext) view.getContext();
             RCTEventEmitter eventEmitter = context.getJSModule(RCTEventEmitter.class);
             int viewId = view.getId();
-
-            WritableMap resourceData = new WritableNativeMap();
-            resourceData.putInt("width", resource.getIntrinsicWidth());
-            resourceData.putInt("height", resource.getIntrinsicHeight());
             
-            eventEmitter.receiveEvent(viewId, REACT_ON_LOAD_EVENT, resourceData);
-            eventEmitter.receiveEvent(viewId, REACT_ON_LOAD_END_EVENT, resourceData);
+            eventEmitter.receiveEvent(viewId, REACT_ON_LOAD_EVENT, mapFromResource(resource));
+            eventEmitter.receiveEvent(viewId, REACT_ON_LOAD_END_EVENT, mapFromResource(resource));
             return false;
         }
     };
+
+    private static WritableMap mapFromResource(GlideDrawable resource) {
+        WritableMap resourceData = new WritableNativeMap();
+        resourceData.putInt("width", resource.getIntrinsicWidth());
+        resourceData.putInt("height", resource.getIntrinsicHeight());
+
+        return resourceData;
+    }
 
     @ReactProp(name = "source")
     public void setSrc(ImageViewWithUrl view, @Nullable ReadableMap source) {

--- a/ios/FastImage/FFFastImageView.m
+++ b/ios/FastImage/FFFastImageView.m
@@ -80,9 +80,14 @@
                             } else {
                                 if (_onFastImageLoad) {
                                     _onFastImageLoad(@{});
-                                    if (_onFastImageLoadEnd) {
-                                        _onFastImageLoadEnd(@{});
-                                    }
+                                }
+                                
+                                NSDictionary* params = @{
+                                                         @"width":[NSNumber numberWithDouble:image.size.width],
+                                                         @"height":[NSNumber numberWithDouble:image.size.height]
+                                                         };
+                                if (_onFastImageLoadEnd) {
+                                    _onFastImageLoadEnd(params);
                                 }
                             }
                         }];


### PR DESCRIPTION
…d onFastImageLoadEnd events

Instead of an empty map, it may be useful to have some information about the newly loaded resource.
Since a user doesn't know the dimensions of a remote resource at load time, providing the dimensions on load end allows the user to adjust the view accordingly if required.