### PR TITLE
Adding `Header Search Paths` to solve problems when:

### DIFF
--- a/ios/FastImage.xcodeproj/project.pbxproj
+++ b/ios/FastImage.xcodeproj/project.pbxproj
@@ -401,6 +401,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/../../react-native/React/**",
+					"$(SRCROOT)/../../../ios/Pods/Headers/Public/**",
+					"${SYMROOT}",
+					"$(BUILT_PRODUCTS_DIR)",
 					"$(SRCROOT)/Vendor/SDWebImage",
 					"$(SRCROOT)/Vendor/SDWebImage/Vendors/FLAnimatedImage/FLAnimatedImage",
 				);
@@ -414,6 +418,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/../../react-native/React/**",
+					"$(SRCROOT)/../../../ios/Pods/Headers/Public/**",
+					"${SYMROOT}",
+					"$(BUILT_PRODUCTS_DIR)",
 					"$(SRCROOT)/Vendor/SDWebImage",
 					"$(SRCROOT)/Vendor/SDWebImage/Vendors/FLAnimatedImage/FLAnimatedImage",
 				);


### PR DESCRIPTION
Adding `Header Search Paths` to solve problems when:
1. Native iOS app integrate react native from `Podfile` and integrate this library from `package.json`.
By adding `$(BUILT_PRODUCTS_DIR)`.
2. In react native 0.51, react native iOS app integrating react native from `Podfile` and adding this library from `node_modules` to iOS project folder `Libraries`.
By adding other lines.

The error likes below:
```
In file included from /Users/OceanHorn/SourceTree/mobile-agent/node_modules/react-native-fast-image/ios/FastImage/RCTConvert+FFFastImage.m:1:
/Users/OceanHorn/SourceTree/mobile-agent/node_modules/react-native-fast-image/ios/FastImage/RCTConvert+FFFastImage.h:1:9: fatal error: 'RCTConvert.h' file not found
#import <React/RCTConvert.h>
        ^~~~~~~~~~~~~~
1 error generated.
```