### PR TITLE
Avoid Exception on Android Build [Issue 47]

### DIFF
--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewPackage.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewPackage.java
@@ -21,4 +21,9 @@ public class FastImageViewPackage implements ReactPackage {
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Collections.<ViewManager>singletonList(new FastImageViewManager());
     }
+    
+    @Override 
+    public List<Class<? extends JavaScriptModule>> createJSModules(){
+        return Collections.emptyList();
+    }
 }


### PR DESCRIPTION
Solve this issue: 
https://github.com/DylanVann/react-native-fast-image/issues/47

To avoid the following exception:

:react-native-fast-image:compileReleaseJavaWithJavac - is not incremental (e.g. outputs have changed, no previous execution, etc.).
[...]/node_modules/react-native-fast-image/android/src/main/java/com/dylanvann/fastimage/FastImageViewPackage.java:14: error: FastImageViewPackage is not abstract and does not override abstract method createJSModules() in ReactPackage
public class FastImageViewPackage implements ReactPackage {
       ^
Note: [...]/node_modules/react-native-fast-image/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
1 error
:react-native-fast-image:compileReleaseJavaWithJavac FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':react-native-fast-image:compileReleaseJavaWithJavac'.
> Compilation failed; see the compiler error output for details.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED