### PR TITLE
Fix bugs when use Fastimage in 'Animated.createAnimatedComponent'

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,9 +56,9 @@ class FastImage extends Component {
     const resolvedSource = resolveAssetSource(source)
 
     return (
-      <View style={[style, styles.imageContainer]}>
+      <View style={[style, styles.imageContainer]}
+            ref={e => (this._root = e)}>
         <FastImageView
-          ref={e => (this._root = e)}
           {...props}
           style={StyleSheet.absoluteFill}
           source={resolvedSource}


### PR DESCRIPTION
For issue-185 : https://github.com/DylanVann/react-native-fast-image/issues/185