### PR TITLE
* sync initial resizeMode & contentMode

### DIFF
--- a/ios/FastImage/FFFastImageViewManager.m
+++ b/ios/FastImage/FFFastImageViewManager.m
@@ -9,7 +9,7 @@ RCT_EXPORT_MODULE(FastImageView)
 
 - (FFFastImageView*)view {
   FFFastImageView* view = [[FFFastImageView alloc] init];
-  view.contentMode = (UIViewContentMode) RCTResizeModeContain;
+  view.contentMode = (UIViewContentMode) RCTResizeModeStretch;
   view.clipsToBounds = YES;
   return view;
 }


### PR DESCRIPTION
fix bug[#19](https://github.com/DylanVann/react-native-fast-image/issues/19)  stretch resizeMode not working, on iOS, resizeMode of FFFastImageView is default 'stretch' (see UIView.h) but contentMode is manually set to 'contain'.