### PR TITLE
useLocalImage: Expose & rename the useful function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ const resolveAssetSource = require('react-native/Libraries/Image/resolveAssetSou
 
 const FastImageViewNativeModule = NativeModules.FastImageView
 
-const useLocalImage = source => {
+export const isLocalSource = source => {
     // No source.
     if (!source) return true
     // No uri.
@@ -52,7 +52,7 @@ class FastImage extends Component {
         } = this.props
 
         // If there's no source or source uri just fallback to Image.
-        if (useLocalImage(source)) {
+        if (isLocalSource(source)) {
             return (
                 <Image
                     ref={this.captureRef}


### PR DESCRIPTION
I am using your handy function check to see when the image source is external and if it is, fade it in, would be cool if I can just import it.