### PR TITLE
Specify type definition file path

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "license": "(MIT AND Apache-2.0)",
   "author": "Dylan Vann <dylanvann@gmail.com> (http://dylanvann.com)",
   "main": "src/index.js",
+  "types": "src/index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/DylanVann/react-native-fast-image.git"


### PR DESCRIPTION
We should specify the type definition file (`index.d.ts`) path in package.json.

TypeScript document says as follows.

>Also note that if your main declaration file is named index.d.ts and lives at the root of the package (next to index.js) you do not need to mark the "types" property, though it is advisable to do so.

https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html

