### PR TITLE
Make it possible to obtain the cache path of an image

### DIFF
--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewModule.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewModule.java
@@ -2,17 +2,37 @@ package com.dylanvann.fastimage;
 
 import android.app.Activity;
 
+import android.support.annotation.Nullable;
 import com.bumptech.glide.Glide;
+import com.bumptech.glide.load.DataSource;
+import com.bumptech.glide.load.engine.GlideException;
 import com.bumptech.glide.load.model.GlideUrl;
+import com.bumptech.glide.request.RequestListener;
+import com.bumptech.glide.request.target.Target;
+
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 
+import java.io.File;
+
 class FastImageViewModule extends ReactContextBaseJavaModule {
 
     private static final String REACT_CLASS = "FastImageView";
+    private static final String ERROR_LOAD_FAILED = "ERROR_LOAD_FAILED";
+
+    private static Object urlForGlideUrl(GlideUrl glideUrl) {
+        final String stringUrl = glideUrl.toString();
+
+        // This will make this work for remote and local images. e.g.
+        //    - file:///
+        //    - content://
+        //    - data:image/png;base64
+        return stringUrl.startsWith("http") ? glideUrl : stringUrl;
+    }
 
     FastImageViewModule(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -33,17 +53,45 @@ class FastImageViewModule extends ReactContextBaseJavaModule {
                 for (int i = 0; i < sources.size(); i++) {
                     final ReadableMap source = sources.getMap(i);
                     final GlideUrl glideUrl = FastImageViewConverter.getGlideUrl(source);
-                    final String stringUrl = glideUrl.toString();
+
                     Glide
                             .with(activity.getApplicationContext())
-                            // This will make this work for remote and local images. e.g.
-                            //    - file:///
-                            //    - content://
-                            //    - data:image/png;base64
-                            .load(stringUrl.startsWith("http") ? glideUrl : stringUrl)
+                            .load(urlForGlideUrl(glideUrl))
                             .apply(FastImageViewConverter.getOptions(source))
                             .preload();
                 }
+            }
+        });
+    }
+
+    @ReactMethod
+    public void loadImage(final ReadableMap source, final Promise promise) {
+        final Activity activity = getCurrentActivity();
+        if (activity == null) return;
+        activity.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                final GlideUrl glideUrl = FastImageViewConverter.getGlideUrl(source);
+
+                Glide
+                        .with(activity.getApplicationContext())
+                        .asFile()
+                        .load(urlForGlideUrl(glideUrl))
+                        .apply(FastImageViewConverter.getOptions(source))
+                        .listener(new RequestListener<File>() {
+                            @Override
+                            public boolean onLoadFailed(@Nullable GlideException e, Object model, Target<File> target, boolean isFirstResource) {
+                                promise.reject(ERROR_LOAD_FAILED, e);
+                                return false;
+                            }
+
+                            @Override
+                            public boolean onResourceReady(File resource, Object model, Target<File> target, DataSource dataSource, boolean isFirstResource) {
+                                promise.resolve(resource.getAbsolutePath());
+                                return false;
+                            }
+                        })
+                        .submit();
             }
         });
     }

--- a/ios/FastImage/FFFastImageViewManager.m
+++ b/ios/FastImage/FFFastImageViewManager.m
@@ -33,5 +33,58 @@ RCT_EXPORT_METHOD(preload:(nonnull NSArray<FFFastImageSource *> *)sources)
     [[SDWebImagePrefetcher sharedImagePrefetcher] prefetchURLs:urls];
 }
 
+RCT_REMAP_METHOD(
+  loadImage,
+  loadImageWithSource: (nonnull FFFastImageSource *)source resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject
+) {
+  SDWebImageManager *imageManager = [SDWebImageManager sharedManager];
+  NSString *cacheKey = [imageManager cacheKeyForURL:source.url];
+  NSString *imagePath = [imageManager.imageCache defaultCachePathForKey:cacheKey];
+  
+  // set headers
+  [source.headers enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSString* header, BOOL *stop) {
+    [imageManager.imageDownloader setValue:header forHTTPHeaderField:key];
+  }];
+
+  // set options
+  SDWebImageOptions options = 0;
+  options |= SDWebImageRetryFailed;
+  switch (source.priority) {
+    case FFFPriorityLow:
+      options |= SDWebImageLowPriority;
+      break;
+    case FFFPriorityNormal:
+      // Priority is normal by default.
+      break;
+    case FFFPriorityHigh:
+      options |= SDWebImageHighPriority;
+      break;
+  }
+  
+  switch (source.cacheControl) {
+    case FFFCacheControlWeb:
+      options |= SDWebImageRefreshCached;
+      break;
+    case FFFCacheControlCacheOnly:
+      options |= SDWebImageCacheMemoryOnly;
+      break;
+    case FFFCacheControlImmutable:
+      break;
+  }
+  
+  // load image
+  [imageManager loadImageWithURL:source.url options:options progress:nil completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL) {
+    if (error != nil) {
+      reject(@"FastImage", @"Failed to load image", error);
+      return;
+    }
+
+    // store image manually (since image manager may call the completion block before storing it in the disk cache)
+    [imageManager.imageCache storeImage:image forKey:cacheKey completion:^{
+      resolve(imagePath);
+    }];
+  }];
+}
+
 @end
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -114,6 +114,8 @@ interface FastImageStatic extends React.ComponentClass<FastImageProperties> {
     }
 
     preload(sources: FastImageSource[]): void
+
+    loadImage(source: FastImageSource): Promise<string>
 }
 
 declare var FastImage: FastImageStatic

--- a/src/index.js
+++ b/src/index.js
@@ -111,6 +111,10 @@ FastImage.preload = sources => {
     FastImageViewNativeModule.preload(sources)
 }
 
+FastImage.loadImage = source => {
+    return FastImageViewNativeModule.loadImage(source)
+}
+
 FastImage.defaultProps = {
     resizeMode: FastImage.resizeMode.cover,
 }


### PR DESCRIPTION
This pull request adds the `FastImage.loadImage(source)` method which fetches the image and returns the path to its copy in the disk cache.

This may not be useful for everybody, but I figured I'd open a PR anyway.