### PR TITLE
Types: make sure headers only accepts key value pairs

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -30,8 +30,8 @@ declare namespace FastImage {
 }
 
 export type FastImageSource = {
-    uri?: string,
-    headers?: object
+    uri?: string
+    headers?: {[key: string]: string}
     priority?: FastImage.Priority
 }
 


### PR DESCRIPTION
When writing the headers for the image, I forgot what the headers accepts, and assumed it was an array and not an object. TS didn't correct me which resulted in #27 