### PR TITLE
missing break.

### DIFF
--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewConverter.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewConverter.java
@@ -79,10 +79,13 @@ class FastImageViewConverter {
                 // If using none then OkHttp integration should be used for caching.
                 diskCacheStrategy = DiskCacheStrategy.NONE;
                 skipMemoryCache = true;
+                break;
             case CACHE_ONLY:
                 onlyFromCache = true;
+                break;
             case IMMUTABLE:
                 // Use defaults.
+                break;
         }
         return new RequestOptions()
                 .diskCacheStrategy(diskCacheStrategy)


### PR DESCRIPTION
when used with web caching strategy, it forces to enable cacheonly policy, which makes it impossible to use the option.