### PR TITLE
Fix cacheControl property in TypeScript types.

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -16,7 +16,7 @@ declare namespace FastImage {
         type center = 'center'
     }
         
-    namespace cache {
+    namespace cacheControl {
         type cacheOnly = 'cacheOnly'
         type immutable = 'immutable'
         type web = 'web'
@@ -34,9 +34,9 @@ declare namespace FastImage {
         FastImage.resizeMode.center
 
     export type Cache =
-        FastImage.cache.cacheOnly |
-        FastImage.cache.immutable |
-        FastImage.cache.web
+        FastImage.cacheControl.cacheOnly |
+        FastImage.cacheControl.immutable |
+        FastImage.cacheControl.web
 }
 
 export type FastImageSource = {

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -1,4 +1,5 @@
 // @flow
+
 import type { ViewProps } from 'react-native/Libraries/Components/View/ViewPropTypes'
 import type { SyntheticEvent } from 'react-native/Libraries/Types/CoreEventTypes'
 


### PR DESCRIPTION
In the TypeScript definitions `FastImage.cache` was incorrectly defined instead of `FastImage.cacheControl`.