### PR TITLE
fix(docs): gradle compile config depreciation

### DIFF
--- a/docs/installation-manual.md
+++ b/docs/installation-manual.md
@@ -30,10 +30,10 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile "com.android.support:appcompat-v7:23.0.1"
-    compile "com.facebook.react:react-native:+"  // From node_modules
-+   compile project(':react-native-fast-image')
+    implementation fileTree(dir: "libs", include: ["*.jar"])
+    implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
+    implementation "com.facebook.react:react-native:+"  // From node_modules
++   implementation project(':react-native-fast-image')
 }
 ```
 


### PR DESCRIPTION
PR facebook/react-native#20767 bumped the version of the Android
Gradle Plugin to v3 which uses the newer Gradle dependency
configurations `implementation` and `api` which make `compile`
obsolete.

PR facebook/react-native#20853 covered the `link` command.

Using `compile` will result in a warning message during app build and
`compile` will be eventually removed by Gradle.