### PR TITLE
Fix TS typings

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -126,9 +126,9 @@ interface FastImageStatic extends React.ComponentClass<FastImageProperties> {
     }
     
     cache: {
-        cacheOnly: FastImage.cache.cacheOnly
-        immutable: FastImage.cache.immutable
-        web: FastImage.cache.web
+        cacheOnly: FastImage.cacheControl.cacheOnly
+        immutable: FastImage.cacheControl.immutable
+        web: FastImage.cacheControl.web
     }
 
     preload(sources: FastImageSource[]): void


### PR DESCRIPTION
Fixes error: `node_modules/react-native-fast-image/src/index.d.ts:129:30 - error TS2694: Namespace 'FastImage' has no exported member 'cache'.`