### PR TITLE
Docs: Added example using project wide configuration

### DIFF
--- a/docs/installation-manual.md
+++ b/docs/installation-manual.md
@@ -37,6 +37,32 @@ dependencies {
 }
 ```
 
+If you've defined *[project-wide
+properties](https://developer.android.com/studio/build/gradle-tips.html)*
+(**recommended**) in your root `build.gradle`, this library will detect
+the presence of the following properties:
+
+```groovy
+buildscript {...}
+allprojects {...}
+
+/**
+ + Project-wide Gradle configuration properties
+ */
+ext {
+    compileSdkVersion   = 26
+    targetSdkVersion    = 26
+    minSdkVersion       = 16    
+    buildToolsVersion   = "26.0.3"
+    supportLibVersion   = "27.1.1"  
+
+    // Uncomment the following line to specify your own glide version
+    // glideVersion = "4.7.1"
+}
+```
+
+
+
 * Edit `android/app/src/main/java/.../MainApplication.java`
 
 ```diff


### PR DESCRIPTION
Reviewing PR #332 and this line in particular: `implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"`. 

I was wondering if we have some explaination on how to configure the `rootProject.ext` stuff in the docs. As it turns out there isnt, so this PR adds an example showing how to use project wide configuration property overrides.