### PR TITLE
Fix FastImage.cache properties in TypeScript types.

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -126,9 +126,9 @@ interface FastImageStatic extends React.ComponentClass<FastImageProperties> {
     }
     
     cache: {
-        cacheOnly: FastImage.cache.cacheOnly
-        immutable: FastImage.cache.immutable
-        web: FastImage.cache.web
+        cacheOnly: FastImage.cacheControl.cacheOnly
+        immutable: FastImage.cacheControl.immutable
+        web: FastImage.cacheControl.web
     }
 
     preload(sources: FastImageSource[]): void


### PR DESCRIPTION
Hi,
I love this lib.
I occurred compile error following:

```
node_modules/react-native-fast-image/src/index.d.ts:129:30 - error TS2694: Namespace 'FastImage' has no exported member 'cache'.

129         cacheOnly: FastImage.cache.cacheOnly
                                 ~~~~~

node_modules/react-native-fast-image/src/index.d.ts:130:30 - error TS2694: Namespace 'FastImage' has no exported member 'cache'.

130         immutable: FastImage.cache.immutable
                                 ~~~~~

node_modules/react-native-fast-image/src/index.d.ts:131:24 - error TS2694: Namespace 'FastImage' has no exported member 'cache'.

131         web: FastImage.cache.web
                           ~~~~~
```

So I had written this patch. Thanks.