### PR TITLE
remove requestManager.clear(view) to stop app crashing when logging o…

### DIFF
--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
@@ -116,10 +116,6 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
 
     @Override
     public void onDropViewInstance(FastImageViewWithUrl view) {
-        // This will cancel existing requests.
-        if (requestManager != null) {
-            requestManager.clear(view);
-        }
 
         if (view.glideUrl != null) {
             final String key = view.glideUrl.toString();


### PR DESCRIPTION
Based on what I found, the requestManager.clear(view) code inside the FastImageViewManager.java was causing the main issue of the "you cannot setTag on a view that Glide is targeting" error.