### PR TITLE
Support WebP images on iOS 12

### DIFF
--- a/react-native-fast-image.podspec
+++ b/react-native-fast-image.podspec
@@ -22,5 +22,6 @@ Pod::Spec.new do |s|
   s.dependency 'React'
   s.dependency 'SDWebImage/Core'
   s.dependency 'SDWebImage/GIF'
+  s.dependency 'SDWebImage/WebP'
   s.dependency 'FLAnimatedImage'
 end


### PR DESCRIPTION
Should
fix #385
fix #298

I tested this in Debug and Release builds with my own app (ios 12) via local images i.e.
```js
<FastImage source={require("../assets/myImage.webp")} />
```

Seems to work without any trouble. Since we are aiming for fast image lib, I think `SDWebImage/WebP` is a good candidate to be included with CocoaPod file?