### PR TITLE
Fix antialias issue on Android 7.0

### DIFF
--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewConverter.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewConverter.java
@@ -15,6 +15,8 @@ import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.bumptech.glide.load.model.GlideUrl;
 import com.bumptech.glide.load.model.Headers;
 import com.bumptech.glide.load.model.LazyHeaders;
+import com.bumptech.glide.load.resource.bitmap.CenterCrop;
+import com.bumptech.glide.load.resource.bitmap.RoundedCorners;
 import com.bumptech.glide.request.RequestOptions;
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.NoSuchKeyException;
@@ -102,12 +104,22 @@ class FastImageViewConverter {
                 // Use defaults.
                 break;
         }
-        return new RequestOptions()
-                .diskCacheStrategy(diskCacheStrategy)
-                .onlyRetrieveFromCache(onlyFromCache)
-                .skipMemoryCache(skipMemoryCache)
-                .priority(priority)
-                .placeholder(TRANSPARENT_DRAWABLE);
+        int borderRadius = 0;
+        try {
+            if (source.hasKey("borderRadius")) {
+                borderRadius = source.getInt("borderRadius");
+            }
+        } catch (NoSuchKeyException e) { }
+        RequestOptions options = new RequestOptions()
+                         .diskCacheStrategy(diskCacheStrategy)
+                         .onlyRetrieveFromCache(onlyFromCache)
+                         .skipMemoryCache(skipMemoryCache)
+                         .priority(priority)
+                         .placeholder(TRANSPARENT_DRAWABLE);
+        if (borderRadius > 0) {
+            options = options.transforms(new CenterCrop(), new RoundedCorners(borderRadius));
+        }
+        return options;
     }
 
     private static FastImageCacheControl getCacheControl(ReadableMap source) {

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewConverter.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewConverter.java
@@ -104,21 +104,19 @@ class FastImageViewConverter {
                 // Use defaults.
                 break;
         }
-        int borderRadius = 0;
-        try {
-            if (source.hasKey("borderRadius")) {
-                borderRadius = source.getInt("borderRadius");
-            }
-        } catch (NoSuchKeyException e) { }
+
         RequestOptions options = new RequestOptions()
-                         .diskCacheStrategy(diskCacheStrategy)
-                         .onlyRetrieveFromCache(onlyFromCache)
-                         .skipMemoryCache(skipMemoryCache)
-                         .priority(priority)
-                         .placeholder(TRANSPARENT_DRAWABLE);
-        if (borderRadius > 0) {
-            options = options.transforms(new CenterCrop(), new RoundedCorners(borderRadius));
+                .diskCacheStrategy(diskCacheStrategy)
+                .onlyRetrieveFromCache(onlyFromCache)
+                .skipMemoryCache(skipMemoryCache)
+                .priority(priority)
+                .placeholder(TRANSPARENT_DRAWABLE);
+
+        if (source.hasKey("borderRadius")) {
+            int borderRadius = source.getInt("borderRadius");
+            options = options.transforms(new CenterCrop(), new RoundedCorners((borderRadius)));
         }
+
         return options;
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import {
     requireNativeComponent,
     ViewPropTypes,
     StyleSheet,
+    PixelRatio
 } from 'react-native'
 
 const FastImageViewNativeModule = NativeModules.FastImageView
@@ -21,6 +22,7 @@ class FastImage extends Component {
     render() {
         const {
             source,
+            resizeMode,
             onLoadStart,
             onProgress,
             onLoad,
@@ -32,7 +34,30 @@ class FastImage extends Component {
             ...props
         } = this.props
 
-        const resolvedSource = Image.resolveAssetSource(source)
+        const borderRadiusObject = style && style.borderRadius ? { borderRadius: Math.round(PixelRatio.getPixelSizeForLayoutSize(style.borderRadius)) } : {}
+        const resolvedSource = Image.resolveAssetSource(source instanceof Object ? Object.assign(source, borderRadiusObject) : source)
+
+        if (!(source instanceof Object)) {
+            return (
+                <View
+                    style={[styles.imageContainer, style]}
+                    ref={this.captureRef}
+                >
+                    <Image
+                        {...props}
+                        style={StyleSheet.absoluteFill}
+                        source={resolvedSource}
+                        resizeMode={resizeMode}
+                        onLoadStart={onLoadStart}
+                        onProgress={onProgress}
+                        onLoad={onLoad}
+                        onError={onError}
+                        onLoadEnd={onLoadEnd}
+                    />
+                    {children}
+                </View>
+            )
+        }
 
         if (fallback) {
             return (

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ import {
     requireNativeComponent,
     ViewPropTypes,
     StyleSheet,
-    PixelRatio
+    PixelRatio,
 } from 'react-native'
 
 const FastImageViewNativeModule = NativeModules.FastImageView
@@ -22,7 +22,6 @@ class FastImage extends Component {
     render() {
         const {
             source,
-            resizeMode,
             onLoadStart,
             onProgress,
             onLoad,
@@ -34,30 +33,13 @@ class FastImage extends Component {
             ...props
         } = this.props
 
-        const borderRadiusObject = style && style.borderRadius ? { borderRadius: Math.round(PixelRatio.getPixelSizeForLayoutSize(style.borderRadius)) } : {}
-        const resolvedSource = Image.resolveAssetSource(source instanceof Object ? Object.assign(source, borderRadiusObject) : source)
-
-        if (!(source instanceof Object)) {
-            return (
-                <View
-                    style={[styles.imageContainer, style]}
-                    ref={this.captureRef}
-                >
-                    <Image
-                        {...props}
-                        style={StyleSheet.absoluteFill}
-                        source={resolvedSource}
-                        resizeMode={resizeMode}
-                        onLoadStart={onLoadStart}
-                        onProgress={onProgress}
-                        onLoad={onLoad}
-                        onError={onError}
-                        onLoadEnd={onLoadEnd}
-                    />
-                    {children}
-                </View>
-            )
-        }
+        const mergedStyle = Array.isArray(style) ? style.reduce((r, c) => Object.assign(r, c), {}) : style
+        const borderRadius = Math.round(PixelRatio.getPixelSizeForLayoutSize(mergedStyle.borderRadius || 0))
+        const resolvedSource = Image.resolveAssetSource(
+            source instanceof Object
+                ? Object.assign(source, borderRadius > 0 && { borderRadius })
+                : source
+        )
 
         if (fallback) {
             return (

--- a/src/index.js
+++ b/src/index.js
@@ -33,12 +33,16 @@ class FastImage extends Component {
             ...props
         } = this.props
 
-        const mergedStyle = Array.isArray(style) ? style.reduce((r, c) => Object.assign(r, c), {}) : style
-        const borderRadius = Math.round(PixelRatio.getPixelSizeForLayoutSize(mergedStyle.borderRadius || 0))
+        const mergedStyle = Array.isArray(style)
+            ? style.reduce((r, c) => Object.assign(r, c), {})
+            : style
+        const borderRadius = Math.round(
+            PixelRatio.getPixelSizeForLayoutSize(mergedStyle.borderRadius || 0),
+        )
         const resolvedSource = Image.resolveAssetSource(
             source instanceof Object
                 ? Object.assign(source, borderRadius > 0 && { borderRadius })
-                : source
+                : source,
         )
 
         if (fallback) {


### PR DESCRIPTION
Pick antialias related commit from #379 and support array type style.
Check the screenshot below. (left: original, right: modified)

<img width="1128" alt="2019-02-18 3 27 26" src="https://user-images.githubusercontent.com/8934513/53151824-63daf900-35f7-11e9-9865-6dfd34935da9.png">

or you can see #159 on your comment, Images on Android aren't antialiased well.