### PR TITLE
Update FastImageViewManager.java

### DIFF
--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
@@ -7,6 +7,7 @@ import android.os.Build;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.RequestManager;
 import com.bumptech.glide.load.model.GlideUrl;
+import com.bumptech.glide.request.Request;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeMap;
@@ -56,9 +57,7 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
     public void setSrc(FastImageViewWithUrl view, @Nullable ReadableMap source) {
         if (source == null || !source.hasKey("uri") || isNullOrEmpty(source.getString("uri"))) {
             // Cancel existing requests.
-            if (requestManager != null) {
-                requestManager.clear(view);
-            }
+            clearView(view);
 
             if (view.glideUrl != null) {
                 FastImageOkHttpProgressGlideModule.forget(view.glideUrl.toStringUrl());
@@ -74,9 +73,7 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
 
         // Cancel existing request.
         view.glideUrl = glideUrl;
-        if (requestManager != null) {
-            requestManager.clear(view);
-        }
+        clearView(view);
 
         String key = glideUrl.toStringUrl();
         FastImageOkHttpProgressGlideModule.expect(key, this);
@@ -117,9 +114,7 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
     @Override
     public void onDropViewInstance(FastImageViewWithUrl view) {
         // This will cancel existing requests.
-        if (requestManager != null) {
-            requestManager.clear(view);
-        }
+        clearView(view);
 
         if (view.glideUrl != null) {
             final String key = view.glideUrl.toString();
@@ -200,5 +195,11 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
             return activity.isFinishing() || activity.isChangingConfigurations();
         }
 
+    }
+
+    private void clearView(FastImageViewWithUrl view) {
+        if (requestManager != null && view != null && view.getTag() != null && view.getTag() instanceof Request) {
+            requestManager.clear(view);
+        }
     }
 }


### PR DESCRIPTION
Dear DylanVann,

First of all, I would like to say thank you for your very good library. It's so great.

The next thing, I create this pull request to fix an exception (IMHO) that I faced with my project.
```
The exception is: **java.lang.IllegalArgumentException** 
The exception detail:
com.facebook.react.bridge.JSApplicationIllegalArgumentException: 
  at com.facebook.react.uimanager.ViewManagersPropertyCache$PropSetter.updateViewProp (ViewManagersPropertyCache.java:95)
  at com.facebook.react.uimanager.ViewManagerPropertyUpdater$FallbackViewManagerSetter.setProperty (ViewManagerPropertyUpdater.java:132)
  at com.facebook.react.uimanager.ViewManagerPropertyUpdater.updateProps (ViewManagerPropertyUpdater.java:51)
  at com.facebook.react.uimanager.ViewManager.updateProperties (ViewManager.java:32)
  at com.facebook.react.uimanager.NativeViewHierarchyManager.updateProperties (NativeViewHierarchyManager.java:138)
  at com.facebook.react.uimanager.UIViewOperationQueue$UpdatePropertiesOperation.execute (UIViewOperationQueue.java:95)
  at com.facebook.react.uimanager.UIViewOperationQueue$1.run (UIViewOperationQueue.java:894)
  at com.facebook.react.uimanager.UIViewOperationQueue.flushPendingBatches (UIViewOperationQueue.java:1001)
  at com.facebook.react.uimanager.UIViewOperationQueue.access$2400 (UIViewOperationQueue.java:46)
  at com.facebook.react.uimanager.UIViewOperationQueue$DispatchUIFrameCallback.doFrameGuarded (UIViewOperationQueue.java:1061)
  at com.facebook.react.uimanager.GuardedFrameCallback.doFrame (GuardedFrameCallback.java:29)
  at com.facebook.react.modules.core.ReactChoreographer$ReactChoreographerDispatcher.doFrame (ReactChoreographer.java:134)
  at com.facebook.react.modules.core.ChoreographerCompat$FrameCallback$1.doFrame (ChoreographerCompat.java:105)
  at android.view.Choreographer$CallbackRecord.run (Choreographer.java:909)
  at android.view.Choreographer.doCallbacks (Choreographer.java:723)
  at android.view.Choreographer.doFrame (Choreographer.java:655)
  at android.view.Choreographer$FrameDisplayEventReceiver.run (Choreographer.java:897)
  at android.os.Handler.handleCallback (Handler.java:789)
  at android.os.Handler.dispatchMessage (Handler.java:98)
  at android.os.Looper.loop (Looper.java:164)
  at android.app.ActivityThread.main (ActivityThread.java:6944)
  at java.lang.reflect.Method.invoke (Native Method)
  at com.android.internal.os.Zygote$MethodAndArgsCaller.run (Zygote.java:327)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1374)
Caused by: java.lang.reflect.InvocationTargetException: 
  at java.lang.reflect.Method.invoke (Native Method)
  at com.facebook.react.uimanager.ViewManagersPropertyCache$PropSetter.updateViewProp (ViewManagersPropertyCache.java:83)
Caused by: java.lang.IllegalArgumentException: 
  at com.bumptech.glide.request.target.ViewTarget.getRequest (**ViewTarget.java:265**)
  at com.bumptech.glide.RequestManager.untrack (RequestManager.java:597)
  at com.bumptech.glide.RequestManager.untrackOrDelegate (RequestManager.java:571)
  at com.bumptech.glide.RequestManager.clear (RequestManager.java:559)
  at com.bumptech.glide.RequestManager.clear (RequestManager.java:544)
  at com.dylanvann.fastimage.FastImageViewManager.setSrc (**FastImageViewManager.java:78**)
```
Best Regard.
Hung Vo
