### PR TITLE
Added cacheOmitURLParams flag to support dynamicURLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,13 @@ Headers to load the image with. e.g. `{ Authorization: 'someAuthToken' }`.
 
 ---
 
+### `source.cacheOmitURLParams?: boolean`
+
+If true will be cached under url without query params
+Useful when image url is dynamic and query params contain security information
+
+---
+
 ### `resizeMode?: enum`
 
 -   `FastImage.resizeMode.contain` - Scale the image uniformly (maintain the image's aspect ratio) so that both dimensions (width and height) of the image will be equal to or less than the corresponding dimension of the view (minus padding).

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageGlideUrlWithoutQueryParams.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageGlideUrlWithoutQueryParams.java
@@ -2,15 +2,29 @@ package com.dylanvann.fastimage;
 
 import com.bumptech.glide.load.model.GlideUrl;
 import com.bumptech.glide.load.model.Headers;
+import java.net.URISyntaxException;
 
 import java.net.URI;
 
 public class FastImageGlideUrlWithoutQueryParams extends GlideUrl {
     private String staticURL;
 
+    private String getUrlWithoutParameters(String url) throws URISyntaxException {
+        URI uri = new URI(url);
+        return new URI(uri.getScheme(),
+            uri.getAuthority(),
+            uri.getPath(),
+            null,
+            uri.getFragment()).toString();
+    }
+
     public FastImageGlideUrlWithoutQueryParams(String url, Headers headers) {
         super(url, headers);
-        staticURL = url.substring(0, url.lastIndexOf('?'));
+        try {
+            staticURL = this.getUrlWithoutParameters(url);
+        } catch (Exception e) {
+            staticURL = url.toString();
+        }
     }
 
     @Override

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageGlideUrlWithoutQueryParams.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageGlideUrlWithoutQueryParams.java
@@ -1,0 +1,25 @@
+package com.dylanvann.fastimage;
+
+import com.bumptech.glide.load.model.GlideUrl;
+import com.bumptech.glide.load.model.Headers;
+
+import java.net.URI;
+
+public class FastImageGlideUrlWithoutQueryParams extends GlideUrl {
+    private String staticURL;
+
+    public FastImageGlideUrlWithoutQueryParams(String url, Headers headers) {
+        super(url, headers);
+        staticURL = url.substring(0, url.lastIndexOf('?'));
+    }
+
+    @Override
+    public String getCacheKey() {
+        return staticURL;
+    }
+
+    @Override
+    public String toString() {
+        return super.getCacheKey();
+    }
+}

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageSource.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageSource.java
@@ -19,6 +19,7 @@ public class FastImageSource extends ImageSource {
     private static final String LOCAL_FILE_SCHEME = "file";
     private Headers mHeaders;
     private Uri mUri;
+    private Boolean cacheOmitURLParams;
 
     public static boolean isBase64Uri(Uri uri) {
         return DATA_SCHEME.equals(uri.getScheme());
@@ -45,13 +46,18 @@ public class FastImageSource extends ImageSource {
     }
 
     public FastImageSource(Context context, String source, @Nullable Headers headers) {
-        this(context, source, 0.0d, 0.0d, headers);
+        this(context, source, 0.0d, 0.0d, headers, false);
     }
 
-    public FastImageSource(Context context, String source, double width, double height, @Nullable Headers headers) {
+    public FastImageSource(Context context, String source, @Nullable Headers headers, @Nullable Boolean cacheOmitURLParams) {
+        this(context, source, 0.0d, 0.0d, headers, cacheOmitURLParams);
+    }
+
+    public FastImageSource(Context context, String source, double width, double height, @Nullable Headers headers, @Nullable Boolean cacheOmitURLParams) {
         super(context, source, width, height);
         mHeaders = headers == null ? Headers.DEFAULT : headers;
         mUri = super.getUri();
+        this.cacheOmitURLParams = cacheOmitURLParams;
 
         if (isResource() && TextUtils.isEmpty(mUri.toString())) {
             throw new Resources.NotFoundException("Local Resource Not Found. Resource: '" + getSource() + "'.");
@@ -107,6 +113,9 @@ public class FastImageSource extends ImageSource {
     }
 
     public GlideUrl getGlideUrl() {
+        if (this.cacheOmitURLParams) {
+            return new FastImageGlideUrlWithoutQueryParams(getUri().toString(), getHeaders());
+        }
         return new GlideUrl(getUri().toString(), getHeaders());
     }
 }

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewConverter.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewConverter.java
@@ -60,7 +60,11 @@ class FastImageViewConverter {
     
     // Resolve the source uri to a file path that android understands.
     static FastImageSource getImageSource(Context context, ReadableMap source) {
-        return new FastImageSource(context, source.getString("uri"), getHeaders(source));
+        Boolean cacheOmitURLParams = false;
+        if (source.hasKey("cacheOmitURLParams")) {
+            cacheOmitURLParams = source.getBoolean("cacheOmitURLParams");
+        }
+        return new FastImageSource(context, source.getString("uri"), getHeaders(source), cacheOmitURLParams);
     }
 
     static Headers getHeaders(ReadableMap source) {

--- a/ios/FastImage.xcodeproj/project.pbxproj
+++ b/ios/FastImage.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		FCC6D1391EB3912D0065F944 /* libSDWebImage.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FCC6D0D01EB38D2F0065F944 /* libSDWebImage.a */; };
+		ED0BC9E3222FBF9600663CC6 /* FFFastImageCacheNoParamMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = ED0BC9E2222FBF9600663CC6 /* FFFastImageCacheNoParamMapper.m */; };
 		FCFB253F1EA5562700F59778 /* FFFastImageSource.m in Sources */ = {isa = PBXBuildFile; fileRef = FCFB25381EA5562700F59778 /* FFFastImageSource.m */; };
 		FCFB25401EA5562700F59778 /* FFFastImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = FCFB253A1EA5562700F59778 /* FFFastImageView.m */; };
 		FCFB25411EA5562700F59778 /* FFFastImageViewManager.m in Sources */ = {isa = PBXBuildFile; fileRef = FCFB253C1EA5562700F59778 /* FFFastImageViewManager.m */; };
@@ -80,6 +81,8 @@
 
 /* Begin PBXFileReference section */
 		A287971D1DE0C0A60081BDFA /* libFastImage.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libFastImage.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		ED0BC9E1222FBF9600663CC6 /* FFFastImageCacheNoParamMapper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FFFastImageCacheNoParamMapper.h; sourceTree = "<group>"; };
+		ED0BC9E2222FBF9600663CC6 /* FFFastImageCacheNoParamMapper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FFFastImageCacheNoParamMapper.m; sourceTree = "<group>"; };
 		FCFB25371EA5562700F59778 /* FFFastImageSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FFFastImageSource.h; sourceTree = "<group>"; };
 		FCFB25381EA5562700F59778 /* FFFastImageSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FFFastImageSource.m; sourceTree = "<group>"; };
 		FCFB25391EA5562700F59778 /* FFFastImageView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FFFastImageView.h; sourceTree = "<group>"; };
@@ -149,6 +152,8 @@
 				FCFB253C1EA5562700F59778 /* FFFastImageViewManager.m */,
 				FCFB253D1EA5562700F59778 /* RCTConvert+FFFastImage.h */,
 				FCFB253E1EA5562700F59778 /* RCTConvert+FFFastImage.m */,
+				ED0BC9E1222FBF9600663CC6 /* FFFastImageCacheNoParamMapper.h */,
+				ED0BC9E2222FBF9600663CC6 /* FFFastImageCacheNoParamMapper.m */,
 			);
 			path = FastImage;
 			sourceTree = "<group>";
@@ -265,6 +270,7 @@
 				FCFB25421EA5562700F59778 /* RCTConvert+FFFastImage.m in Sources */,
 				FCFB25401EA5562700F59778 /* FFFastImageView.m in Sources */,
 				FCFB253F1EA5562700F59778 /* FFFastImageSource.m in Sources */,
+				ED0BC9E3222FBF9600663CC6 /* FFFastImageCacheNoParamMapper.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/FastImage/FFFastImageCacheNoParamMapper.h
+++ b/ios/FastImage/FFFastImageCacheNoParamMapper.h
@@ -1,0 +1,21 @@
+//
+//  FFFastImageCacheNoParamMapper.h
+//  FastImage
+//
+//  Created by Kamil Badyla on 06/03/2019.
+//  Copyright © 2019 vovkasm. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface FFFastImageCacheNoParamMapper : NSObject
+
++ (instancetype)shared;
+- (void)add:(NSURL*)url;
+- (void)remove:(NSURL*)url;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/FastImage/FFFastImageCacheNoParamMapper.m
+++ b/ios/FastImage/FFFastImageCacheNoParamMapper.m
@@ -1,0 +1,61 @@
+//
+//  FFFastImageCacheNoParamMapper.m
+//  FastImage
+//
+//  Created by Kamil Badyla on 06/03/2019.
+//  Copyright © 2019 vovkasm. All rights reserved.
+//
+
+#import "FFFastImageCacheNoParamMapper.h"
+#import <SDWebImage/SDWebImageManager.h>
+
+@implementation NSURL (StaticUrl)
+
+- (NSURL*)staticURL {
+	return [[NSURL alloc] initWithScheme:self.scheme host:self.host path:self.path];
+}
+
+@end
+
+@interface FFFastImageCacheNoParamMapper ()
+
+@property (strong) NSMutableSet *staticUrls;
+
+@end
+
+@implementation FFFastImageCacheNoParamMapper
+
++ (instancetype)shared {
+	static FFFastImageCacheNoParamMapper *_shared = nil;
+	static dispatch_once_t onceToken;
+	dispatch_once(&onceToken, ^{
+		_shared = [FFFastImageCacheNoParamMapper new];
+	});
+	
+	return _shared;
+}
+
+- (id)init {
+	self = [super init];
+	if (self) {
+		_staticUrls = [NSMutableSet new];
+		[[SDWebImageManager sharedManager] setCacheKeyFilter:^NSString * _Nullable(NSURL * _Nullable url) {
+			NSString *staticURLString = [[url staticURL] absoluteString];
+			if ([_staticUrls containsObject:staticURLString]) {
+				return staticURLString;
+			}
+			return url.absoluteString;
+		}];
+	}
+	return self;
+}
+
+- (void)add:(NSURL*)url {
+	[_staticUrls addObject:[url staticURL].absoluteString];
+}
+
+- (void)remove:(NSURL*)url {
+	[_staticUrls removeObject:[url staticURL].absoluteString];
+}
+
+@end

--- a/ios/FastImage/FFFastImageSource.h
+++ b/ios/FastImage/FFFastImageSource.h
@@ -24,10 +24,13 @@ typedef NS_ENUM(NSInteger, FFFCacheControl) {
 @property (nonatomic) NSDictionary *headers;
 // cache control mode
 @property (nonatomic) FFFCacheControl cacheControl;
+// omit URL query params for cacheKey
+@property (nonatomic) BOOL cacheOmitURLParams;
 
 - (instancetype)initWithURL:(NSURL *)url
                    priority:(FFFPriority)priority
                     headers:(NSDictionary *)headers
-               cacheControl:(FFFCacheControl)cacheControl;
+               cacheControl:(FFFCacheControl)cacheControl
+		 cacheOmitURLParams:(BOOL)cacheOmitURLParams;
 
 @end

--- a/ios/FastImage/FFFastImageSource.m
+++ b/ios/FastImage/FFFastImageSource.m
@@ -6,6 +6,7 @@
                    priority:(FFFPriority)priority
                     headers:(NSDictionary *)headers
                cacheControl:(FFFCacheControl)cacheControl
+		 cacheOmitURLParams:(BOOL)cacheOmitURLParams
 {
     self = [super init];
     if (self) {
@@ -13,6 +14,7 @@
         _priority = priority;
         _headers = headers;
         _cacheControl = cacheControl;
+		_cacheOmitURLParams = cacheOmitURLParams;
     }
     return self;
 }

--- a/ios/FastImage/FFFastImageView.m
+++ b/ios/FastImage/FFFastImageView.m
@@ -1,4 +1,5 @@
 #import "FFFastImageView.h"
+#import "FFFastImageCacheNoParamMapper.h"
 
 @interface FFFastImageView()
 
@@ -170,6 +171,12 @@
             case FFFCacheControlImmutable:
                 break;
         }
+		
+		if (_source.cacheOmitURLParams) {
+			[[FFFastImageCacheNoParamMapper shared] add:_source.url];
+		} else {
+			[[FFFastImageCacheNoParamMapper shared] remove:_source.url];
+		}
         
         if (self.onFastImageLoadStart) {
             self.onFastImageLoadStart(@{});

--- a/ios/FastImage/RCTConvert+FFFastImage.m
+++ b/ios/FastImage/RCTConvert+FFFastImage.m
@@ -43,7 +43,11 @@ RCT_ENUM_CONVERTER(FFFCacheControl, (@{
         }
     }
     
-    FFFastImageSource *imageSource = [[FFFastImageSource alloc] initWithURL:uri priority:priority headers:headers cacheControl:cacheControl];
+    FFFastImageSource *imageSource = [[FFFastImageSource alloc] initWithURL:uri
+																   priority:priority
+																	headers:headers
+															   cacheControl:cacheControl
+														 cacheOmitURLParams:[self BOOL:json[@"cacheOmitURLParams"]]];
     
     return imageSource;
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -49,6 +49,7 @@ export type FastImageSource = {
     headers?: { [key: string]: string }
     priority?: FastImage.Priority
     cache?: FastImage.Cache
+    cacheOmitURLParams?: boolean
 }
 
 export interface ImageStyle extends FlexStyle, TransformsStyle, ShadowStyleIOS {

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -46,6 +46,7 @@ export type FastImageSource = {
     headers?: Object,
     priority?: Priorities,
     cache?: CacheControls,
+    cacheOmitURLParams?: boolean
 }
 
 export type FastImageProps = $ReadOnly<{|


### PR DESCRIPTION
Sometimes Image URL consists of security or analytic query params which can make image caching pointless. 

For example, if you have following image URL:

`https://example.amazonaws.com/5B9DA6464B07467C9CDA5DF5C187904F/88ed2de4-ab2b-4ae2-a63a-ce4afb687a2e/thumbnails/1551781958.jpeg?X-Amz-Security-Token=123&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20190305T114254Z&X-Amz-SignedHeaders=host&X-Amz-Expires=1800&X-Amz-Credential=4556%2Feu-west-1%2Fs3%2Faws4_request&X-Amz-Signature=caf1fa0f049aa3a409490eaa12891cd3ee605ab48ed68eb7498a72112e580dcb`

You can set `cacheOmitURLParams` which will cache this image under 

`https://example.amazonaws.com/5B9DA6464B07467C9CDA5DF5C187904F/88ed2de4-ab2b-4ae2-a63a-ce4afb687a2e/thumbnails/1551781958.jpeg`

Usage: 
```js
<FastImage source={{ uri, cache: 'web', cacheOmitURLParams: true }} />
```

Issue https://github.com/DylanVann/react-native-fast-image/issues/380