### PR TITLE
iOS: Memory Leak, Auto-retry download, Shared Resource Propagation

### DIFF
--- a/ios/FastImage/FFFastImageView.m
+++ b/ios/FastImage/FFFastImageView.m
@@ -119,8 +119,7 @@
         }];
         
         // Set priority.
-        SDWebImageOptions options = 0;
-        options |= SDWebImageRetryFailed;
+        SDWebImageOptions options = SDWebImageRetryFailed; // Auto-retry to download if failed
         switch (_source.priority) {
             case FFFPriorityLow:
                 options |= SDWebImageLowPriority;

--- a/ios/FastImage/FFFastImageView.m
+++ b/ios/FastImage/FFFastImageView.m
@@ -31,14 +31,14 @@
     }
 }
 
-- (void)setOnFastImageLoadEnd:(RCTBubblingEventBlock)onFastImageLoadEnd {
+- (void)setOnFastImageLoadEnd:(RCTDirectEventBlock)onFastImageLoadEnd {
     _onFastImageLoadEnd = onFastImageLoadEnd;
     if (self.hasCompleted) {
         _onFastImageLoadEnd(@{});
     }
 }
 
-- (void)setOnFastImageLoad:(RCTBubblingEventBlock)onFastImageLoad {
+- (void)setOnFastImageLoad:(RCTDirectEventBlock)onFastImageLoad {
     _onFastImageLoad = onFastImageLoad;
     if (self.hasCompleted) {
         _onFastImageLoad(self.onLoadEvent);
@@ -52,7 +52,7 @@
     }
 }
 
-- (void)setOnFastImageLoadStart:(RCTBubblingEventBlock)onFastImageLoadStart {
+- (void)setOnFastImageLoadStart:(RCTDirectEventBlock)onFastImageLoadStart {
     if (_source && !self.hasSentOnLoadStart) {
         _onFastImageLoadStart = onFastImageLoadStart;
         onFastImageLoadStart(@{});

--- a/ios/FastImage/FFFastImageView.m
+++ b/ios/FastImage/FFFastImageView.m
@@ -68,8 +68,8 @@
                          @"width":[NSNumber numberWithDouble:image.size.width],
                          @"height":[NSNumber numberWithDouble:image.size.height]
                          };
-    if (_onFastImageLoad) {
-        _onFastImageLoad(self.onLoadEvent);
+    if (self.onFastImageLoad) {
+        self.onFastImageLoad(self.onLoadEvent);
     }
 }
 
@@ -186,7 +186,7 @@
                                 NSTimeInterval delayInSeconds = (retry + 1) * 5.0; // will retry after 0.5, 1.0 or 1.5 seconds
                                 dispatch_time_t trigger = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayInSeconds * NSEC_PER_SEC));
                                 dispatch_after(trigger, dispatch_get_main_queue(), ^{
-                                    [weakSelf downloadImage:_source options:options retry:retry + 1];
+                                    [weakSelf downloadImage:source options:options retry:retry + 1];
                                 });
                             }
                         } else {


### PR DESCRIPTION
# Changelogs

**1- Use weak self reference in progression and completion block to avoid memory leaks**

It's recommended to never retain the strong reference to self into blocks.

*Blocks maintain strong references to any captured objects, including self, which means that it’s easy to end up with a strong reference cycle*

[Avoid Strong Reference Cycles when Capturing self](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ProgrammingWithObjectiveC/WorkingwithBlocks/WorkingwithBlocks.html#//apple_ref/doc/uid/TP40011210-CH8-SW16)

**2- Broadcast a notification when different instance share the same source succeed to download an image**

As mentioned in #432, when two instance of **FFFastImageView** share the same source, but one of them fail to download while the second succeed, the result of the second won't be shared with the first one. Which result with instance of **FFFastImageView** staying empty.

To remedy this issue I used `NSNotificationCenter` to attach an observer and post a notification whenever an instance of **FFFastImageView** succeed to download. Works very well on my own project, it's a game changer for me.

**3- Implement auto-retry failed download logic**

As mentioned in #432, we can't only rely on `SDWebImageRetryFailed` to auto-retry when a download failed.

Also apparently this feature has been requested on the SDWebImage repository and is still waiting for implementation.
https://github.com/SDWebImage/SDWebImage/issues/2587

So I implemented my own auto-retry mechanism which will retry after 1.5s, 3s and 4.5s before failing. In total it makes the timeout for the image download to 9s.

Let me know if you want to bring more flexibility to this feature.

**4- Update Objective-C syntax to highlight instance properties**

Being a former Objective-C iOS engineer myself, I updated the code to the modern Objective-C syntax.

[Adopting Modern Objective-C](https://developer.apple.com/library/archive/releasenotes/ObjectiveC/ModernizationObjC/AdoptingModernObjective-C/AdoptingModernObjective-C.html) 
[Migrating to Modern Objective-C](https://download.developer.apple.com/wwdc_2012/wwdc_2012_session_pdfs/session_413__migrating_to_modern_objectivec.pdf) See slides 47 and 48

Updating the syntax helped me to realized that their were more invocation to strong self in blocks that I initially thought. See #398 

**5- Use RCTDirectEventBlock instead of RCTBubblingEventBlock**

From what I understand from the React Native documentation.

[RCTBubblingEventBlock](https://facebook.github.io/react-native/docs/native-components-ios#events)  are used for UI related events (e.g: the user pinch the map)
[RCTDirectEventBlock](https://facebook.github.io/react-native/docs/custom-webview-ios#adding-new-events-and-properties) are used for more straight events (e.g web page failed to load callbacks).

So I replaced all the **RCTBubblingEventBlock** types by **RCTDirectEventBlock** as we don't handle user interaction.

Also found this [gist](
https://gist.github.com/chourobin/f83f3b3a6fd2053fad29fff69524f91c#ios) about the subject.