### PR TITLE
Fix:failed to load image while RN rebuilding view hierachy

### DIFF
--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
@@ -102,7 +102,7 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
                     //    - android.resource://
                     //    - data:image/png;base64
                     .load(imageSource.getSourceForLoad())
-                    .apply(FastImageViewConverter.getOptions(source))
+                    .apply(FastImageViewConverter.getOptions(source).override(view.getWidth(), view.getHeight()))
                     .listener(new FastImageRequestListener(key))
                     .into(view);
         }


### PR DESCRIPTION
While RN rebuilding view hierachy,the LayoutParams of ImageViews have been reset.Glide refuse to do further process if overrideWidth=0 or overrideHeight=0.