### PR TITLE
delete from cache by URL

### DIFF
--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewModule.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewModule.java
@@ -1,15 +1,23 @@
 package com.dylanvann.fastimage;
 
 import android.app.Activity;
+import android.support.annotation.Nullable;
 
 import com.bumptech.glide.Glide;
+import com.bumptech.glide.load.DataSource;
+import com.bumptech.glide.load.engine.GlideException;
 import com.bumptech.glide.load.model.GlideUrl;
+import com.bumptech.glide.request.RequestListener;
+import com.bumptech.glide.request.target.Target;
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.views.imagehelper.ImageSource;
+
+import java.io.File;
 
 class FastImageViewModule extends ReactContextBaseJavaModule {
 
@@ -45,7 +53,7 @@ class FastImageViewModule extends ReactContextBaseJavaModule {
                             //    - data:image/png;base64
                             .load(
                                     imageSource.isBase64Resource() ? imageSource.getSource() :
-                                    imageSource.isResource() ? imageSource.getUri() : imageSource.getGlideUrl()
+                                            imageSource.isResource() ? imageSource.getUri() : imageSource.getGlideUrl()
                             )
                             .apply(FastImageViewConverter.getOptions(source))
                             .preload();
@@ -53,4 +61,31 @@ class FastImageViewModule extends ReactContextBaseJavaModule {
             }
         });
     }
+
+    @ReactMethod
+    public void deleteImage(final String url, final Promise promise) {
+        final Activity activity = getCurrentActivity();
+        if (activity == null) return;
+        Glide
+                .with(activity.getApplicationContext())
+                .asFile()
+                .load(url)
+                .listener(new RequestListener<File>() {
+                    @Override
+                    public boolean onLoadFailed(@Nullable GlideException e, Object model, Target<File> target, boolean isFirstResource) {
+
+                        return false;
+                    }
+
+                    @Override
+                    public boolean onResourceReady(File resource, Object model, Target<File> target, DataSource dataSource, boolean isFirstResource) {
+                        String url = resource.getAbsolutePath();
+                        resource.delete();
+                        promise.resolve(url);
+                        return false;
+                    }
+                })
+                .submit();
+    }
+
 }

--- a/ios/FastImage/FFFastImageViewManager.m
+++ b/ios/FastImage/FFFastImageViewManager.m
@@ -2,6 +2,7 @@
 #import "FFFastImageView.h"
 
 #import <SDWebImage/SDWebImagePrefetcher.h>
+#import <SDWebImage/SDImageCache.h>
 
 @implementation FFFastImageViewManager
 
@@ -31,6 +32,14 @@ RCT_EXPORT_METHOD(preload:(nonnull NSArray<FFFastImageSource *> *)sources)
     }];
 
     [[SDWebImagePrefetcher sharedImagePrefetcher] prefetchURLs:urls];
+}
+
+RCT_EXPORT_METHOD(deleteImage:(NSString *)url)
+{
+    NSURL *nsurl = [NSURL URLWithString:url];
+    SDWebImageManager *imageManager = [SDWebImageManager sharedManager];
+    NSString *cacheKey = [imageManager cacheKeyForURL:nsurl];
+    [[SDImageCache sharedImageCache] removeImageForKey:cacheKey fromDisk:TRUE withCompletion:0];
 }
 
 @end


### PR DESCRIPTION
This code add to use **FastImage.deleteImage(url)** method on ios and android.
It useful, when you want update image with same url or for more cache control.

Example:
```
FastImage.deleteImage(url).then(deletedImagePath => {
                    console.log(deletedImagePath);
};
```
Its async method.