### PR TITLE
UPDATE - proguard rules on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ If you use Proguard you will need to add these lines to `android/app/proguard-ru
 ```
 -keep public class com.dylanvann.fastimage.* {*;}
 -keep public class com.dylanvann.fastimage.** {*;}
+-keep public class * implements com.bumptech.glide.module.GlideModule
+-keep public class * extends com.bumptech.glide.module.AppGlideModule
+-keep public enum com.bumptech.glide.load.ImageHeaderParser$** {
+  **[] $VALUES;
+  public *;
 ```
 
 ## Properties


### PR DESCRIPTION
When proguard is enable, the app return this error:
`java.lang.IllegalArgumentException: Unable to find GlideModule implementation`

It`s a common issues, so I just add the fix on Readme file:
```
-keep public class * implements com.bumptech.glide.module.GlideModule
-keep public class * extends com.bumptech.glide.module.AppGlideModule
-keep public enum com.bumptech.glide.load.ImageHeaderParser$** {
  **[] $VALUES;
  public *;
```