### PR TITLE
Fix local resource cache issue, fixes #402

### DIFF
--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewConverter.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewConverter.java
@@ -16,6 +16,7 @@ import com.bumptech.glide.load.model.GlideUrl;
 import com.bumptech.glide.load.model.Headers;
 import com.bumptech.glide.load.model.LazyHeaders;
 import com.bumptech.glide.request.RequestOptions;
+import com.bumptech.glide.signature.ApplicationVersionSignature;
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.NoSuchKeyException;
 import com.facebook.react.bridge.ReadableMap;
@@ -29,6 +30,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import javax.annotation.Nullable;
+
+import static com.bumptech.glide.request.RequestOptions.signatureOf;
 
 class FastImageViewConverter {
     private static final Drawable TRANSPARENT_DRAWABLE = new ColorDrawable(Color.TRANSPARENT);
@@ -81,7 +84,7 @@ class FastImageViewConverter {
         return headers;
     }
 
-    static RequestOptions getOptions(ReadableMap source) {
+    static RequestOptions getOptions(Context context, FastImageSource imageSource, ReadableMap source) {
         // Get priority.
         final Priority priority = FastImageViewConverter.getPriority(source);
         // Get cache control method.
@@ -102,12 +105,25 @@ class FastImageViewConverter {
                 // Use defaults.
                 break;
         }
-        return new RequestOptions()
-                .diskCacheStrategy(diskCacheStrategy)
-                .onlyRetrieveFromCache(onlyFromCache)
-                .skipMemoryCache(skipMemoryCache)
-                .priority(priority)
-                .placeholder(TRANSPARENT_DRAWABLE);
+
+        RequestOptions options = new RequestOptions()
+            .diskCacheStrategy(diskCacheStrategy)
+            .onlyRetrieveFromCache(onlyFromCache)
+            .skipMemoryCache(skipMemoryCache)
+            .priority(priority)
+            .placeholder(TRANSPARENT_DRAWABLE);
+        
+        if (imageSource.isResource()) {
+            // Every local resource (drawable) in Android has its own unique numeric id, which are
+            // generated at build time. Although these ids are unique, they are not guaranteed unique
+            // across builds. The underlying glide implementation caches these resources. To make
+            // sure the cache does not return the wrong image, we should clear the cache when the
+            // application version changes. Adding a cache signature for only these local resouces
+            // solves this issue: https://github.com/DylanVann/react-native-fast-image/issues/402
+            options = options.apply(signatureOf(ApplicationVersionSignature.obtain(context)));
+        }
+
+        return options;                
     }
 
     private static FastImageCacheControl getCacheControl(ReadableMap source) {

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewConverter.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewConverter.java
@@ -118,7 +118,7 @@ class FastImageViewConverter {
             // generated at build time. Although these ids are unique, they are not guaranteed unique
             // across builds. The underlying glide implementation caches these resources. To make
             // sure the cache does not return the wrong image, we should clear the cache when the
-            // application version changes. Adding a cache signature for only these local resouces
+            // application version changes. Adding a cache signature for only these local resources
             // solves this issue: https://github.com/DylanVann/react-native-fast-image/issues/402
             options = options.apply(signatureOf(ApplicationVersionSignature.obtain(context)));
         }

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
@@ -103,7 +103,7 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
                     //    - android.resource://
                     //    - data:image/png;base64
                     .load(imageSource.getSourceForLoad())
-                    .apply(FastImageViewConverter.getOptions(source))
+                    .apply(FastImageViewConverter.getOptions(context, imageSource, source))
                     .listener(new FastImageRequestListener(key))
                     .into(view);
         }

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewModule.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewModule.java
@@ -47,7 +47,7 @@ class FastImageViewModule extends ReactContextBaseJavaModule {
                                     imageSource.isBase64Resource() ? imageSource.getSource() :
                                     imageSource.isResource() ? imageSource.getUri() : imageSource.getGlideUrl()
                             )
-                            .apply(FastImageViewConverter.getOptions(source))
+                            .apply(FastImageViewConverter.getOptions(activity, imageSource, source))
                             .preload();
                 }
             }


### PR DESCRIPTION
_Clears the glide cache for local resources across releases._

## Context

Every local resource (drawable) in Android has its own unique numeric id, which are generated at build time. Although these ids are unique, they are not guaranteed unique across builds. The underlying glide implementation caches these resources. Because this numeric id can be reassigned to another resource at build time, we need to make sure we handle this case correctly. 

Basically to make sure the cache does not return the wrong (old) image, we should clear the cache when the application version changes. Adding a cache signature for only these local resources solves this issue: https://github.com/DylanVann/react-native-fast-image/issues/402

Glide itself solves this issue the same way: https://github.com/bumptech/glide/blob/v4.9.0/library/src/main/java/com/bumptech/glide/RequestBuilder.java#L542