### PR TITLE
fix proguard rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ If you use Proguard you will need to add these lines to `android/app/proguard-ru
 -keep public enum com.bumptech.glide.load.ImageHeaderParser$** {
   **[] $VALUES;
   public *;
+}
 ```
 
 ## Properties


### PR DESCRIPTION
add missing `}`.

Fixes

```
java.io.IOException: proguard.ParseException: Expecting class member description or closing '}' before end of line
```