### PR TITLE
Upgrade the vendored SDWebImage to v5.0.5, fix the Archive issue for Application don't use CocoaPods

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,6 @@ and
 
 ## Usage
 
-**You may want to install version 5 (`yarn add react-native-fast-image@^5`) until [this issue](https://github.com/DylanVann/react-native-fast-image/issues/468) is resolved.**
-
 ```bash
 # Install
 yarn add react-native-fast-image


### PR DESCRIPTION
See issue: #468

This is because the wrong project configuration for SDWebImage, which copy the headers into the target products. The [v5.0.5](https://github.com/SDWebImage/SDWebImage/releases/tag/5.0.5) version fix this issue.

Note this issue does not impact the users who use CocoaPods.