### PR TITLE
Update react-native-fast-image.podspec

### DIFF
--- a/react-native-fast-image.podspec
+++ b/react-native-fast-image.podspec
@@ -19,6 +19,5 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m}"
   s.exclude_files = "ios/Vendor/**/*.{h,m}"
 
-  s.dependency 'React'
   s.dependency 'SDWebImage', '~> 5.0'
 end


### PR DESCRIPTION
removed deprecated React dependency
(https://cocoapods.org/pods/react)