### PR TITLE
Fixed IllegalArgumentException crash when context was instance of Con…

### DIFF
--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
@@ -2,6 +2,7 @@ package com.dylanvann.fastimage;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.ContextWrapper;
 import android.graphics.PorterDuff;
 import android.os.Build;
 
@@ -182,32 +183,43 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
 
 
     private static boolean isValidContextForGlide(final Context context) {
-        if (context == null) {
+        Activity activity = getActivityFromContext(context);
+
+        if (activity == null) {
             return false;
         }
+
+        return !isActivityDestroyed(activity);
+    }
+
+    private static Activity getActivityFromContext(final Context context) {
         if (context instanceof Activity) {
-            final Activity activity = (Activity) context;
-            if (isActivityDestroyed(activity)) {
-                return false;
-            }
+            return (Activity) context;
         }
 
         if (context instanceof ThemedReactContext) {
             final Context baseContext = ((ThemedReactContext) context).getBaseContext();
             if (baseContext instanceof Activity) {
-                final Activity baseActivity = (Activity) baseContext;
-                return !isActivityDestroyed(baseActivity);
+                return (Activity) baseContext;
+            }
+
+            if (baseContext instanceof ContextWrapper) {
+                final ContextWrapper contextWrapper = (ContextWrapper) baseContext;
+                final Context wrapperBaseContext = contextWrapper.getBaseContext();
+                if (wrapperBaseContext instanceof Activity) {
+                    return (Activity) wrapperBaseContext;
+                }
             }
         }
 
-        return true;
+        return null;
     }
 
     private static boolean isActivityDestroyed(Activity activity) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
             return activity.isDestroyed() || activity.isFinishing();
         } else {
-            return activity.isFinishing() || activity.isChangingConfigurations();
+            return activity.isDestroyed() || activity.isFinishing() || activity.isChangingConfigurations();
         }
 
     }


### PR DESCRIPTION
Hi! This is a fix that we at Skyscanner needed to implement in order to avoid an `IllegalArgumentException: You cannot start a load for a destroyed activity` crash.

The solution is to add an extra check to consider the case when the `baseContext` is an instance of `ContextWrapper`. 

As it was before it was never calling the `isActivityDestroyed()` method as neither of the checks of `if (instance of...` was evaluating to true.