### PR TITLE
no activity.isDestroyed() in android jellybean 16

### DIFF
--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
@@ -219,7 +219,7 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
             return activity.isDestroyed() || activity.isFinishing();
         } else {
-            return activity.isDestroyed() || activity.isFinishing() || activity.isChangingConfigurations();
+            return activity.isFinishing() || activity.isChangingConfigurations();
         }
 
     }


### PR DESCRIPTION
fixes a crash in android 4.1(api 16)