### PR TITLE
Documenting quick fix pointed out in issues #534 and in #257

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -8,3 +8,5 @@ If you have problems you can try:
 - Clearing watchman's watches. (`watchman watch-del-all`)
 - Clearing React Native's packager cache. (`react-native start --reset-cache`)
 - Clearing React Native's iOS build folder. (`rm -rf ios/build`)
+- Updating Pod repos. (`cd ios && pod repo update`)
+- Reinstalling Pods. (`cd ios && pod install`)


### PR DESCRIPTION
It helps when you migrate to the newer versions of react-native-fast-image which support 60.0 from older versions
https://github.com/DylanVann/react-native-fast-image/issues/534#issuecomment-519015141