### PR TITLE
fix #556 issue Invalid prop `source` supplied to `Image`

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,43 @@ const YourImage = () => (
     />
 )
 ```
+OR
+```jsx
+import FastImage from 'react-native-fast-image'
+
+const YourImage = () => (
+    <FastImage
+        style={{ width: 200, height: 200 }}
+        source={{ uri: "/path/to/your/image.png" }}
+        resizeMode={FastImage.resizeMode.contain}
+    />
+)
+```
+-   please add FireProvider by yourself like below
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-path name="external_files" path="."/>
+</paths>
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    ...
+    <application
+        ...
+        <provider
+            android:name=".FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/provider_paths"/>
+        </provider>
+    </application>
+</manifest>
+```
+
+
 
 ## Are you using Glide already using an AppGlideModule?
 

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageSource.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageSource.java
@@ -9,7 +9,11 @@ import com.bumptech.glide.load.model.GlideUrl;
 import com.bumptech.glide.load.model.Headers;
 import com.facebook.react.views.imagehelper.ImageSource;
 
+import java.io.File;
+
 import javax.annotation.Nullable;
+
+import androidx.core.content.FileProvider;
 
 public class FastImageSource extends ImageSource {
     private static final String DATA_SCHEME = "data";
@@ -52,6 +56,13 @@ public class FastImageSource extends ImageSource {
         super(context, source, width, height);
         mHeaders = headers == null ? Headers.DEFAULT : headers;
         mUri = super.getUri();
+
+        if (mUri == null || TextUtils.isEmpty(mUri.toString())) {
+            Uri localUri = FileProvider.getUriForFile(context,
+                    context.getApplicationContext().getPackageName() + ".provider",
+                    new File(source));
+            mUri = localUri;
+        }
 
         if (isResource() && TextUtils.isEmpty(mUri.toString())) {
             throw new Resources.NotFoundException("Local Resource Not Found. Resource: '" + getSource() + "'.");


### PR DESCRIPTION
-  sometimes we download online image to local manually.
- all the downloaded image's stored to External storage(or Internal)
- It's hard to transfer absolute path to URI. 
- use `FireProvider` to transfer the absolute path to URI