### PR TITLE
Add react-native link command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ and
 yarn add react-native-fast-image
 ```
 
+```bash
+react-native link react-native-fast-image
+```
+
 ```jsx
 import FastImage from 'react-native-fast-image'
 


### PR DESCRIPTION
Looks like this instruction was missing from README -- added back in.

Feel free to add further clarification for lower versions of RN (assuming that the statement about latest working on 0.60+ is adequate).