### PR TITLE
Performance improvements in SDWebImage

### DIFF
--- a/ios/FastImage/FFFastImageView.m
+++ b/ios/FastImage/FFFastImageView.m
@@ -148,7 +148,7 @@
         }];
         
         // Set priority.
-        SDWebImageOptions options = SDWebImageRetryFailed || SDWebImageScaleDownLargeImages;
+        SDWebImageOptions options = SDWebImageRetryFailed | SDWebImageScaleDownLargeImages;
         switch (_source.priority) {
             case FFFPriorityLow:
                 options |= SDWebImageLowPriority;

--- a/ios/FastImage/FFFastImageView.m
+++ b/ios/FastImage/FFFastImageView.m
@@ -148,7 +148,7 @@
         }];
         
         // Set priority.
-        SDWebImageOptions options = SDWebImageRetryFailed;
+        SDWebImageOptions options = SDWebImageRetryFailed || SDWebImageScaleDownLargeImages;
         switch (_source.priority) {
             case FFFPriorityLow:
                 options |= SDWebImageLowPriority;

--- a/ios/FastImage/FFFastImageView.m
+++ b/ios/FastImage/FFFastImageView.m
@@ -17,6 +17,7 @@
 - (id) init {
     self = [super init];
     self.resizeMode = RCTResizeModeCover;
+    self.maxBufferSize = 1024 * 1024;
     self.clipsToBounds = YES;
     return self;
 }


### PR DESCRIPTION
- Set maxBufferSize to 1MB to improve GIF loading
- Add SDWebImageScaleDownLargeImages by default