### PR TITLE
Allow iOS to clear the tintColor property.

### DIFF
--- a/ios/FastImage/FFFastImageView.m
+++ b/ios/FastImage/FFFastImageView.m
@@ -61,16 +61,16 @@
 }
 
 - (void)setImageColor:(UIColor *)imageColor {
-    if (imageColor != nil) {
-        _imageColor = imageColor;
-        super.image = [self makeImage:super.image withTint:self.imageColor];
-    }
+    _imageColor = imageColor;
+    super.image = [self makeImage:super.image withTint:self.imageColor];
 }
 
 - (UIImage*)makeImage:(UIImage *)image withTint:(UIColor *)color {
     UIImage *newImage = [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
     UIGraphicsBeginImageContextWithOptions(image.size, NO, newImage.scale);
-    [color set];
+    if (color != nil) {
+       [color set];
+    }
     [newImage drawInRect:CGRectMake(0, 0, image.size.width, newImage.size.height)];
     newImage = UIGraphicsGetImageFromCurrentImageContext();
     UIGraphicsEndImageContext();


### PR DESCRIPTION
By allowing the image color to be set to nil, it's possible to set and then unset a tint color.

This now matches the Android behavior defined in FastImageViewManager.java

[FastImageViewManager](https://github.com/DylanVann/react-native-fast-image/blob/master/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java#L116)
