### PR TITLE
fix: remove cache property if using fallback

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,16 +23,17 @@ function FastImageBase({
     forwardedRef,
     ...props
 }) {
-    const resolvedSource = Image.resolveAssetSource(source)
-
     if (fallback) {
+        const { 'cache': _, ...sourceWithoutCache } = source
+        const resolvedSourceForFallback = Image.resolveAssetSource(sourceWithoutCache)
+
         return (
             <View style={[styles.imageContainer, style]} ref={forwardedRef}>
                 <Image
                     {...props}
                     tintColor={tintColor}
                     style={StyleSheet.absoluteFill}
-                    source={resolvedSource}
+                    source={resolvedSourceForFallback}
                     onLoadStart={onLoadStart}
                     onProgress={onProgress}
                     onLoad={onLoad}
@@ -44,6 +45,8 @@ function FastImageBase({
         )
     }
 
+    const resolvedSource = Image.resolveAssetSource(source)
+    
     return (
         <View style={[styles.imageContainer, style]} ref={forwardedRef}>
             <FastImageView

--- a/src/index.js
+++ b/src/index.js
@@ -24,8 +24,9 @@ function FastImageBase({
     ...props
 }) {
     if (fallback) {
-        const { 'cache': _, ...sourceWithoutCache } = source
-        const resolvedSourceForFallback = Image.resolveAssetSource(sourceWithoutCache)
+        const cleanedSource = { ...source }
+        delete cleanedSource.cache
+        const resolvedSourceForImage = Image.resolveAssetSource(cleanedSource)
 
         return (
             <View style={[styles.imageContainer, style]} ref={forwardedRef}>
@@ -33,7 +34,7 @@ function FastImageBase({
                     {...props}
                     tintColor={tintColor}
                     style={StyleSheet.absoluteFill}
-                    source={resolvedSourceForFallback}
+                    source={resolvedSourceForImage}
                     onLoadStart={onLoadStart}
                     onProgress={onProgress}
                     onLoad={onLoad}
@@ -46,7 +47,7 @@ function FastImageBase({
     }
 
     const resolvedSource = Image.resolveAssetSource(source)
-    
+
     return (
         <View style={[styles.imageContainer, style]} ref={forwardedRef}>
             <FastImageView


### PR DESCRIPTION
iOS image has its own properties for cache and if fallback is true and regular image is being rendered we can't set FastImage's cache value because it doesn't match.

It closes https://github.com/DylanVann/react-native-fast-image/issues/470