### PR TITLE
Fix and update Gradle setup

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -57,7 +57,7 @@ repositories {
     jcenter()
 }
 
-def glideVersion = safeExtGet('glideVersion', '4.9.0')
+def glideVersion = safeExtGet('glideVersion', '4.10.0')
 
 dependencies {
     //noinspection GradleDynamicVersion

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,47 +1,42 @@
-buildscript {
-    repositories {
-        jcenter()
-        google()
-    }
-    dependencies {
-        classpath "com.android.tools.build:gradle:3.4.0"
-    }
-}
-
-apply plugin: "com.android.library"
-
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
 
-def _excludeAppGlideModule = safeExtGet("excludeAppGlideModule", false)
-def _buildToolsVersion = safeExtGet("buildToolsVersion", "28.0.3")
-def _compileSdkVersion = safeExtGet("compileSdkVersion", 28)
-def _glideVersion = safeExtGet("glideVersion", "4.9.0")
-def _minSdkVersion = safeExtGet("minSdkVersion", 16)
-def _reactNativeVersion = safeExtGet("reactNative", "+")
-def _targetSdkVersion = safeExtGet("targetSdkVersion", 28)
+buildscript {
+    // The Android Gradle plugin is only required when opening the android folder stand-alone.
+    // This avoids unnecessary downloads and potential conflicts when the library is included as a
+    // module dependency in an application project.
+    if (project == rootProject) {
+        repositories {
+            google()
+            jcenter()
+        }
+        dependencies {
+            classpath 'com.android.tools.build:gradle:3.5.3'
+        }
+    }
+}
+
+apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion _compileSdkVersion
-    buildToolsVersion _buildToolsVersion
-
+    compileSdkVersion safeExtGet('compileSdkVersion', 28)
+    buildToolsVersion safeExtGet('buildToolsVersion', '28.0.3')
+    defaultConfig {
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 28)
+        versionCode 1
+        versionName "1.0"
+    }
     sourceSets {
         main {
             java {
-                if (_excludeAppGlideModule) {
+                if (safeExtGet('excludeAppGlideModule', false)) {
                     srcDir "src"
                     exclude "**/FastImageGlideModule.java"
                 }
             }
         }
-    }
-
-    defaultConfig {
-        minSdkVersion _minSdkVersion
-        targetSdkVersion _targetSdkVersion
-        versionCode 1
-        versionName "1.0"
     }
     lintOptions {
         abortOnError false
@@ -49,22 +44,25 @@ android {
 }
 
 repositories {
-    mavenCentral()
-    google()
+    mavenLocal()
     maven {
-        url "https://maven.google.com"
+        // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+        url "$rootDir/../node_modules/react-native/android"
     }
+    maven {
+        // Android JSC is installed from npm
+        url "$rootDir/../node_modules/jsc-android/dist"
+    }
+    google()
+    jcenter()
 }
+
+def glideVersion = safeExtGet('glideVersion', '4.9.0')
 
 dependencies {
     //noinspection GradleDynamicVersion
-    implementation "com.facebook.react:react-native:${_reactNativeVersion}"
-    implementation "androidx.core:core:1.0.0"
-    implementation "androidx.appcompat:appcompat:1.0.0"
-    implementation "androidx.annotation:annotation:1.0.0"
-    implementation("com.github.bumptech.glide:glide:${_glideVersion}")
-    implementation("com.github.bumptech.glide:annotations:${_glideVersion}")
-    annotationProcessor 'com.android.support:support-annotations:28.0.0-alpha3'
-    annotationProcessor "com.github.bumptech.glide:compiler:${_glideVersion}"
-    implementation("com.github.bumptech.glide:okhttp3-integration:${_glideVersion}")
+    implementation 'com.facebook.react:react-native:+'  // From node_modules
+    implementation "com.github.bumptech.glide:glide:${glideVersion}"
+    implementation "com.github.bumptech.glide:okhttp3-integration:${glideVersion}"
+    annotationProcessor "com.github.bumptech.glide:compiler:${glideVersion}"
 }

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewWithUrl.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewWithUrl.java
@@ -1,11 +1,12 @@
 package com.dylanvann.fastimage;
 
 import android.content.Context;
-import android.widget.ImageView;
+
+import androidx.appcompat.widget.AppCompatImageView;
 
 import com.bumptech.glide.load.model.GlideUrl;
 
-class FastImageViewWithUrl extends ImageView {
+class FastImageViewWithUrl extends AppCompatImageView {
     public GlideUrl glideUrl;
 
     public FastImageViewWithUrl(Context context) {


### PR DESCRIPTION
Three commits here:

The first one changes the Gradle script to include the Android Gradle plugin _conditionally_. That way, it's only used when the `android` folder is opened individually, and it does not interfere with consumer projects using this library. It also updates the plugin to `3.5.3`.

See [this thread](https://github.com/facebook/react-native/pull/25569), and [this comment](https://github.com/facebook/react-native/pull/25569#issuecomment-532504277) for details and more information.

The second commit updates `glide` from `4.9.0` to `4.10.0`. The newer version drops a dependency on the deprecated support libs, avoiding a Lint error.

Finally the third commit fixes the only remaining Lint issue in the Android code, by replacing `ImageView` with `AppCompatImageView` from the AndroidX libraries.

With these changes, the Android code now builds without any Lint issues! :+1:

<sub><sup>Once approved, please use a *normal* GitHub merge (i.e. **NO rebase/squash** merge) to integrate the commit(s) from the PR head branch. The changes are broken up into meaningful, [atomic commits](https://www.freshconsulting.com/atomic-commits/), and my branch should already be up-to-date with the latest base branch. If it isn't, or if you want me to change anything, please let me know, and I will update the branch as soon as possible. Thank you!</sup></sub>