### PR TITLE
CocoaPods - Use Version Tag

### DIFF
--- a/RNFastImage.podspec
+++ b/RNFastImage.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.platforms     = { :ios => "8.0", :tvos => "9.0" }
   s.framework     = 'UIKit'
   s.requires_arc  = true
-  s.source        = { :git => "https://github.com/DylanVann/react-native-fast-image.git" }
+  s.source        = { :git => "https://github.com/DylanVann/react-native-fast-image.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m}"
 
   s.dependency 'React'


### PR DESCRIPTION
The current setup for react-native-fast-image always attempts to pull the source from the `mainline` branch.  I just ran into an issue where I was attempting to install an old version of react-native-fast-image, but instead it fetched the mainline version which was incompatible.  

This change ensures the version which is downloaded from NPM matches the version of the source.