### PR TITLE
CocoaPods - Add Tag Version

### DIFF
--- a/RNFastImage.podspec
+++ b/RNFastImage.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.platforms     = { :ios => "8.0", :tvos => "9.0" }
   s.framework     = 'UIKit'
   s.requires_arc  = true
-  s.source        = { :git => "https://github.com/DylanVann/react-native-fast-image.git" }
+  s.source        = { :git => "https://github.com/DylanVann/react-native-fast-image.git", :tag => "v#{s.version} }
   s.source_files  = "ios/**/*.{h,m}"
 
   s.dependency 'React'


### PR DESCRIPTION
I faced an issue today where I attempted to install a previous specific version of `react-native-fast-image` into my codebase.  I saw that the version installed by CocoaPods did not match the version in my `node_modules` directory – it was pulling the HEAD version always.  This resolves that issue.

Why?
* This change will make the CocoaPods version which is installed match the NodeJS version used.  
  Currently, CocoaPods will install the latest version on head which could not match the JavaScript
  version of the library.

Changes:
1. Use the version tag to match the version installed by CocoaPods to that coming the from the `package.json` file.