### PR TITLE
Use React Native shared CookieJar on Android

### DIFF
--- a/android/src/main/java/com/dylanvann/fastimage/FastImageCookieJar.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageCookieJar.java
@@ -1,0 +1,38 @@
+package com.dylanvann.fastimage;
+
+import android.webkit.CookieManager;
+
+import java.util.Collections;
+import java.util.List;
+
+import okhttp3.Cookie;
+import okhttp3.CookieJar;
+import okhttp3.HttpUrl;
+
+public class FastImageCookieJar implements CookieJar {
+    private CookieManager cookieManager;
+
+    private CookieManager getCookieManager() {
+        if (cookieManager == null) {
+            cookieManager = CookieManager.getInstance();
+        }
+        
+        return cookieManager;
+    }
+
+    @Override
+    public void saveFromResponse(HttpUrl url, List<Cookie> cookies) {
+        // Do nothing
+    }
+
+    @Override
+    public List<Cookie> loadForRequest(HttpUrl url) {
+        String cookie = getCookieManager().getCookie(url.toString());
+
+        if (cookie == null || cookie.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return Collections.singletonList(Cookie.parse(url, cookie));
+    }
+}

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageOkHttpProgressGlideModule.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageOkHttpProgressGlideModule.java
@@ -45,6 +45,7 @@ public class FastImageOkHttpProgressGlideModule extends LibraryGlideModule {
         OkHttpClient client = OkHttpClientProvider
                 .getOkHttpClient()
                 .newBuilder()
+                .cookieJar(new FastImageCookieJar())
                 .addInterceptor(createInterceptor(progressListener))
                 .build();
         OkHttpUrlLoader.Factory factory = new OkHttpUrlLoader.Factory(client);


### PR DESCRIPTION
On Android, we could reuse the same CookieJar that React Native uses, so we won't have to append authorization headers manually.

The usage is pretty simple, we just have to make sure we got a `Set-Cookie` response in React Native, then those cookies will be automatically appended to matching requests with `react-native-fast-image`.