### PR TITLE
Fix Source's Cache type

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -31,7 +31,7 @@ const priority = {
     high: 'high',
 } as const
 
-type Cache = 'low' | 'normal' | 'high'
+type Cache = 'immutable' | 'web' | 'cacheOnly'
 
 const cacheControl = {
     // Ignore headers, use uri as cache key, fetch only if not in cache.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,15 +23,13 @@ const resizeMode = {
     center: 'center',
 } as const
 
-export type Priority = 'low' | 'normal' | 'high'
-
 const priority = {
     low: 'low',
     normal: 'normal',
     high: 'high',
 } as const
 
-export type Cache = 'immutable' | 'web' | 'cacheOnly'
+export type Priority = typeof priority[keyof typeof priority]
 
 const cacheControl = {
     // Ignore headers, use uri as cache key, fetch only if not in cache.
@@ -41,6 +39,8 @@ const cacheControl = {
     // Only load from cache.
     cacheOnly: 'cacheOnly',
 } as const
+
+export type Cache = typeof cacheControl[keyof typeof cacheControl]
 
 export type Source = {
     uri?: string

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,7 +23,7 @@ const resizeMode = {
     center: 'center',
 } as const
 
-type Priority = 'low' | 'normal' | 'high'
+export type Priority = 'low' | 'normal' | 'high'
 
 const priority = {
     low: 'low',
@@ -31,7 +31,7 @@ const priority = {
     high: 'high',
 } as const
 
-type Cache = 'immutable' | 'web' | 'cacheOnly'
+export type Cache = 'immutable' | 'web' | 'cacheOnly'
 
 const cacheControl = {
     // Ignore headers, use uri as cache key, fetch only if not in cache.


### PR DESCRIPTION
`Cache` property type was equal to `Priority` (with `low | normal | high` values)
However, `FastImage.cacheControl` contains `immutable`, `web` and `cacheOnly` values, so the types are not matching

Fixed by changing `Cache` type to `'immutable' | 'web' | 'cacheOnly'`