### PR TITLE
fix: accessibilityIgnoresInvertColors prop not recognised when using TypeScript

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,6 +10,7 @@ import {
     ShadowStyleIOS,
     StyleProp,
     TransformsStyle,
+    AccessibilityProps
 } from 'react-native'
 
 const FastImageViewNativeModule = NativeModules.FastImageView
@@ -78,7 +79,7 @@ export interface ImageStyle extends FlexStyle, TransformsStyle, ShadowStyleIOS {
     opacity?: number
 }
 
-export interface FastImageProps {
+export interface FastImageProps extends AccessibilityProps {
     source: Source | number
     resizeMode?: ResizeMode
     fallback?: boolean

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,7 +10,7 @@ import {
     ShadowStyleIOS,
     StyleProp,
     TransformsStyle,
-    AccessibilityProps
+    AccessibilityProps,
 } from 'react-native'
 
 const FastImageViewNativeModule = NativeModules.FastImageView


### PR DESCRIPTION
# Background
 - in testing [eslint-plugin-react-native-a11y](https://github.com/FormidableLabs/eslint-plugin-react-native-a11y) with `react-native-fast-image`, I noticed that a11y props such as `accessibilityIgnoresInvertColors` are missing from FastImage's TypeScript definitions
- in theory the "proper" fix for this would be to make `FastImageProps` extend `ImagePropsBase` from React Native, because ultimately FastImage [spreads Props down](https://github.com/DylanVann/react-native-fast-image/blob/master/src/index.tsx#L150-L160) to React Native's Image component (including a11y props)
- attempting this "proper" fix proved problematic in practice due to incompatibilities between the two interfaces
- instead rather than extending the entirety of `ImagePropsBase` (which itself extends `AccessibilityProps`) we can resolve this by simply also extending `AccessibilityProps`

# Before
<img width="560" alt="Screenshot 2020-04-10 at 11 38 33 2" src="https://user-images.githubusercontent.com/2393035/78986146-7fb69c80-7b22-11ea-88d6-1fa6f34d2b13.png">
<img width="1341" alt="Screenshot 2020-04-10 at 11 38 33" src="https://user-images.githubusercontent.com/2393035/78986155-85ac7d80-7b22-11ea-8a8e-1faa5f727fab.png">

# After
<img width="610" alt="Screenshot 2020-04-10 at 11 38 59" src="https://user-images.githubusercontent.com/2393035/78986169-8c3af500-7b22-11ea-8d33-56f024de0703.png">
<img width="613" alt="Screenshot 2020-04-10 at 11 38 59 2" src="https://user-images.githubusercontent.com/2393035/78986174-90671280-7b22-11ea-95da-9746e6ca50e4.png">
