### PR TITLE
Bump SDWebImageWebPCoder version to 0.6.1

### DIFF
--- a/RNFastImage.podspec
+++ b/RNFastImage.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/**/*.{h,m}"
 
   s.dependency 'React'
-  s.dependency 'SDWebImage', '~> 5.0'
-  s.dependency 'SDWebImageWebPCoder', '~> 0.4.1'
+  s.dependency 'SDWebImage', '~> 5.7'
+  s.dependency 'SDWebImageWebPCoder', '~> 0.6.1'
 end

--- a/RNFastImage.podspec
+++ b/RNFastImage.podspec
@@ -17,5 +17,5 @@ Pod::Spec.new do |s|
 
   s.dependency 'React'
   s.dependency 'SDWebImage', '~> 5.7'
-  s.dependency 'SDWebImageWebPCoder', '~> 0.6.1'
+  s.dependency 'SDWebImageWebPCoder', '~> 0.6'
 end


### PR DESCRIPTION
This enabled multi-thread encoding for improved performance. Also, SDWebImage 5.7 seems to be required https://github.com/SDWebImage/SDWebImageWebPCoder/pull/35 so I'm bumping it also to enforce it for people that are upgrading.