### PR TITLE
fix(android): make center ResizeMode work correctly

### DIFF
--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewConverter.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewConverter.java
@@ -55,7 +55,7 @@ class FastImageViewConverter {
                 put("contain", ScaleType.FIT_CENTER);
                 put("cover", ScaleType.CENTER_CROP);
                 put("stretch", ScaleType.FIT_XY);
-                put("center", ScaleType.CENTER);
+                put("center", ScaleType.CENTER_INSIDE);
             }};
     
     // Resolve the source uri to a file path that android understands.


### PR DESCRIPTION
Howdy,

First of all great library - Second, I noticed that `ResizeMode.center` works differently on iOS and Android. iOS has the desired behavior whereas android is using a different `ScaleType`

I checked out the source code for one of Facebook's unit tests on Android for resize mode stuff and saw that they were using `ScaleType.CENTER_INSIDE` – this library is using `ScaleType.CENTER` 

Making this simple change fixed the behavior - LMK if any other info is needed in order to merge this

Thanks in advance