### PR TITLE
Use Node.js LTS version on CI (fixes Circle CI builds)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
     build-and-test:
         docker:
-            - image: 'circleci/node:latest'
+            - image: 'circleci/node:lts'
         steps:
             - checkout
             - restore_cache:


### PR DESCRIPTION
`yarn build` on Circle CI fails with ` Cannot find module '@babel/compat-data/corejs3-shipped-proposals'` error. This error appears in [unstable Node.js versions](https://github.com/nodejs/node/issues/32852).

Changed Circle CI config to use LTS Node.js version