### PR TITLE
fixes wrong cache type

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -31,7 +31,7 @@ const priority = {
     high: 'high',
 } as const
 
-type Cache = 'low' | 'normal' | 'high'
+type Cache = 'immutable' | 'web' | 'cacheOnly'
 
 const cacheControl = {
     // Ignore headers, use uri as cache key, fetch only if not in cache.


### PR DESCRIPTION
Cache type for typescript was wrong. The typing for flow is the right one.