### PR TITLE
fix: xcode 12 compatibility

### DIFF
--- a/RNFastImage.podspec
+++ b/RNFastImage.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.source        = { :git => "https://github.com/DylanVann/react-native-fast-image.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m}"
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
   s.dependency 'SDWebImage', '~> 5.8'
   s.dependency 'SDWebImageWebPCoder', '~> 0.6.1'
 end


### PR DESCRIPTION
Xcode 12 fails to build if a module depends on React instead of React-Core. Reference - https://github.com/facebook/react-native/issues/29633#issuecomment-694187116. Even though some packages might not be affected right now, it's still considered a [good change](https://github.com/facebook/react-native/issues/29633#issuecomment-694534795)