### PR TITLE
add possibility to set placeholder image (defaultSource)

### DIFF
--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewConverter.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewConverter.java
@@ -84,7 +84,7 @@ class FastImageViewConverter {
         return headers;
     }
 
-    static RequestOptions getOptions(Context context, FastImageSource imageSource, ReadableMap source) {
+    static RequestOptions getOptions(Context context, FastImageSource imageSource, ReadableMap source, Drawable placeholderDrawable) {
         // Get priority.
         final Priority priority = FastImageViewConverter.getPriority(source);
         // Get cache control method.
@@ -111,7 +111,7 @@ class FastImageViewConverter {
             .onlyRetrieveFromCache(onlyFromCache)
             .skipMemoryCache(skipMemoryCache)
             .priority(priority)
-            .placeholder(TRANSPARENT_DRAWABLE);
+            .placeholder(placeholderDrawable != null ? placeholderDrawable : TRANSPARENT_DRAWABLE);
         
         if (imageSource.isResource()) {
             // Every local resource (drawable) in Android has its own unique numeric id, which are

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
@@ -97,6 +97,8 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
         int viewId = view.getId();
         eventEmitter.receiveEvent(viewId, REACT_ON_LOAD_START_EVENT, new WritableNativeMap());
 
+        Drawable placeholderDrawable = view.getPlaceholderDrawable();
+
         if (requestManager != null) {
             requestManager
                     // This will make this work for remote and local images. e.g.
@@ -106,8 +108,7 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
                     //    - android.resource://
                     //    - data:image/png;base64
                     .load(imageSource.getSourceForLoad())
-                    .placeholder(view.getPlaceholderDrawable())
-                    .apply(FastImageViewConverter.getOptions(context, imageSource, source))
+                    .apply(FastImageViewConverter.getOptions(context, imageSource, source, placeholderDrawable))
                     .listener(new FastImageRequestListener(key))
                     .into(view);
         }

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.ContextWrapper;
 import android.graphics.PorterDuff;
+import android.graphics.drawable.Drawable;
 import android.os.Build;
 
 import com.bumptech.glide.Glide;
@@ -17,6 +18,7 @@ import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
+import com.facebook.react.views.imagehelper.ResourceDrawableIdHelper;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -104,10 +106,17 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
                     //    - android.resource://
                     //    - data:image/png;base64
                     .load(imageSource.getSourceForLoad())
+                    .placeholder(view.getPlaceholderDrawable())
                     .apply(FastImageViewConverter.getOptions(context, imageSource, source))
                     .listener(new FastImageRequestListener(key))
                     .into(view);
         }
+    }
+
+    @ReactProp(name = "defaultSource")
+    public void setDefaultSource(FastImageViewWithUrl view, @Nullable String source) {
+        Drawable drawable = ResourceDrawableIdHelper.getInstance().getResourceDrawable(view.getContext(), source);
+        view.setPlaceholderDrawable(drawable);
     }
 
     @ReactProp(name = "tintColor", customType = "Color")

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewModule.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewModule.java
@@ -47,7 +47,7 @@ class FastImageViewModule extends ReactContextBaseJavaModule {
                                     imageSource.isBase64Resource() ? imageSource.getSource() :
                                     imageSource.isResource() ? imageSource.getUri() : imageSource.getGlideUrl()
                             )
-                            .apply(FastImageViewConverter.getOptions(activity, imageSource, source))
+                            .apply(FastImageViewConverter.getOptions(activity, imageSource, source, null))
                             .preload();
                 }
             }

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewWithUrl.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewWithUrl.java
@@ -1,12 +1,22 @@
 package com.dylanvann.fastimage;
 
 import android.content.Context;
+import android.graphics.drawable.Drawable;
 import android.widget.ImageView;
 
 import com.bumptech.glide.load.model.GlideUrl;
 
 class FastImageViewWithUrl extends ImageView {
+    private Drawable placeholderDrawable;
     public GlideUrl glideUrl;
+
+    public Drawable getPlaceholderDrawable() {
+        return placeholderDrawable;
+    }
+
+    public void setPlaceholderDrawable(Drawable placeholderDrawable) {
+        this.placeholderDrawable = placeholderDrawable;
+    }
 
     public FastImageViewWithUrl(Context context) {
         super(context);

--- a/ios/FastImage/FFFastImageView.h
+++ b/ios/FastImage/FFFastImageView.h
@@ -18,6 +18,7 @@
 @property (nonatomic, assign) RCTResizeMode resizeMode;
 @property (nonatomic, strong) FFFastImageSource *source;
 @property (nonatomic, strong) UIColor *imageColor;
+@property (nonatomic, strong) UIImage *placeholderImage;
 
 @end
 

--- a/ios/FastImage/FFFastImageView.m
+++ b/ios/FastImage/FFFastImageView.m
@@ -196,7 +196,7 @@
 - (void)downloadImage:(FFFastImageSource *) source options:(SDWebImageOptions) options context:(SDWebImageContext *)context {
     __weak typeof(self) weakSelf = self; // Always use a weak reference to self in blocks
     [self sd_setImageWithURL:_source.url
-            placeholderImage:nil
+            placeholderImage:_placeholderImage
                      options:options
                      context:context
                     progress:^(NSInteger receivedSize, NSInteger expectedSize, NSURL * _Nullable targetURL) {

--- a/ios/FastImage/FFFastImageViewManager.m
+++ b/ios/FastImage/FFFastImageViewManager.m
@@ -19,6 +19,7 @@ RCT_EXPORT_VIEW_PROPERTY(onFastImageError, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onFastImageLoad, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onFastImageLoadEnd, RCTDirectEventBlock)
 RCT_REMAP_VIEW_PROPERTY(tintColor, imageColor, UIColor)
+RCT_REMAP_VIEW_PROPERTY(defaultSource, placeholderImage, UIImage)
 
 RCT_EXPORT_METHOD(preload:(nonnull NSArray<FFFastImageSource *> *)sources)
 {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,6 +11,8 @@ import {
     StyleProp,
     TransformsStyle,
     AccessibilityProps,
+    ImageURISource,
+    Platform
 } from 'react-native'
 
 const FastImageViewNativeModule = NativeModules.FastImageView
@@ -81,6 +83,7 @@ export interface ImageStyle extends FlexStyle, TransformsStyle, ShadowStyleIOS {
 
 export interface FastImageProps extends AccessibilityProps {
     source: Source | number
+    defaultSource?: ImageURISource | number
     resizeMode?: ResizeMode
     fallback?: boolean
 
@@ -130,6 +133,7 @@ export interface FastImageProps extends AccessibilityProps {
 
 function FastImageBase({
     source,
+    defaultSource,
     tintColor,
     onLoadStart,
     onProgress,
@@ -155,6 +159,7 @@ function FastImageBase({
                     {...props}
                     style={StyleSheet.absoluteFill}
                     source={resolvedSource}
+                    defaultSource={defaultSource}
                     onLoadStart={onLoadStart}
                     onProgress={onProgress}
                     onLoad={onLoad as any}
@@ -168,6 +173,9 @@ function FastImageBase({
     }
 
     const resolvedSource = Image.resolveAssetSource(source as any)
+    const resolvedDefaultSource = !defaultSource || Platform.OS === 'ios'
+        ? defaultSource
+        : Image.resolveAssetSource(defaultSource)?.uri || null
 
     return (
         <View style={[styles.imageContainer, style]} ref={forwardedRef}>
@@ -176,6 +184,7 @@ function FastImageBase({
                 tintColor={tintColor}
                 style={StyleSheet.absoluteFill}
                 source={resolvedSource}
+                defaultSource={resolvedDefaultSource}
                 onFastImageLoadStart={onLoadStart}
                 onFastImageProgress={onProgress}
                 onFastImageLoad={onLoad}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -173,9 +173,9 @@ function FastImageBase({
     }
 
     const resolvedSource = Image.resolveAssetSource(source as any)
-    const resolvedDefaultSource = !defaultSource || Platform.OS === 'ios'
+    const resolvedDefaultSource = Platform.OS === 'ios'
         ? defaultSource
-        : Image.resolveAssetSource(defaultSource)?.uri || null
+        : (defaultSource && Image.resolveAssetSource(defaultSource)?.uri) || null
 
     return (
         <View style={[styles.imageContainer, style]} ref={forwardedRef}>


### PR DESCRIPTION
Related to https://github.com/DylanVann/react-native-fast-image/issues/638

Both Glide and SDWebImage libraries supports placeholder images. This PR adds possibility to set placeholder image using "defaultSource" prop.