### PR TITLE
Update OnLoadEvent typings

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -54,6 +54,7 @@ export interface OnLoadEvent {
     nativeEvent: {
         width: number
         height: number
+        target: number
     }
 }
 


### PR DESCRIPTION
This exposes the target property of the onLoadEvent.

Our use case for needing this is that when the image loads, we take the target (which is the react tag) and pass it over the bridge into Obj-C code so that we can grab a reference to the UIImageView and perform some manipulations.