### PR TITLE
Add instructions to install for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ and
 
 ```bash
 yarn add react-native-fast-image
+cd ios && pod install
 ```
 
 ```jsx


### PR DESCRIPTION
With this instruction will finish correctly the installation process for iOS and prevent errors when try to use the component (like "FastImageView" was not found in the UIManager)