### PR TITLE
fix: make sure not to crash when source is invalid

### DIFF
--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
@@ -72,6 +72,27 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
 
         //final GlideUrl glideUrl = FastImageViewConverter.getGlideUrl(view.getContext(), source);
         final FastImageSource imageSource = FastImageViewConverter.getImageSource(view.getContext(), source);
+        if (imageSource.getUri().toString().length() == 0) {
+            ThemedReactContext context = (ThemedReactContext) view.getContext();
+            RCTEventEmitter eventEmitter = context.getJSModule(RCTEventEmitter.class);
+            int viewId = view.getId();
+            WritableMap event = new WritableNativeMap();
+            event.putString("message", "Invalid source prop:" + source);
+            eventEmitter.receiveEvent(viewId, REACT_ON_ERROR_EVENT, event);
+
+            // Cancel existing requests.
+            if (requestManager != null) {
+                requestManager.clear(view);
+            }
+
+            if (view.glideUrl != null) {
+                FastImageOkHttpProgressGlideModule.forget(view.glideUrl.toStringUrl());
+            }
+            // Clear the image.
+            view.setImageDrawable(null);
+            return;
+        }
+
         final GlideUrl glideUrl = imageSource.getGlideUrl();
 
         // Cancel existing request.


### PR DESCRIPTION
Hello, found an issue on android, causing a crash if the uri is invalid.

Suggested solution: trigger onError instead


To reproduce, you can use: `source={{ uri: '/' }}`

Fixes #407 