### PR TITLE
added mavenCentral() for gradle builds

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
     repositories {
+        mavenCentral()
         jcenter()
         google()
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,6 @@
 buildscript {
     repositories {
         mavenCentral()
-        jcenter()
         google()
     }
     dependencies {


### PR DESCRIPTION
As jCenter is shutting down so adding mavenCentral() so that gradle builds fail