### PR TITLE
feat(ios): add cancel image downloading when image remove from render

### DIFF
--- a/ios/FastImage/FFFastImageView.m
+++ b/ios/FastImage/FFFastImageView.m
@@ -1,5 +1,6 @@
 #import "FFFastImageView.h"
 #import <SDWebImage/UIImage+MultiFormat.h>
+#import <SDWebImage/UIView+WebCache.h>
 
 @interface FFFastImageView()
 
@@ -228,5 +229,8 @@
                     }];
 }
 
-@end
+- (void)dealloc {
+    [self sd_cancelCurrentImageLoad];
+}
 
+@end


### PR DESCRIPTION
add cancel image downloading when `isEnable` will `false` and start image loading when `isEnable` will `true`. you can see below example

# Example
```
const [isEnable, setIsEnable] = useState(true);

{isEnable && (
        <FastImage
          style={{width: 400, height: 400}}
          source={{
            uri: "https://upload.wikimedia.org/wikipedia/commons/f/ff/Pizigani_1367_Chart_10MB.jpg",
            priority: FastImage.priority.normal,
          }}
          resizeMode={FastImage.resizeMode.contain}
        />
      )}
```

#### Note: this feature is already implement in android but ios was missing this feature
ref: https://github.com/DylanVann/react-native-fast-image/blob/0439f7190f141e51a391c84890cdd8a7067c6ad3/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java#L62