### PR TITLE
Added react@17 as peer dependency for react-native 0.64 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
         "typescript": "^3.9.7"
     },
     "peerDependencies": {
-        "react": "^16.8.6",
+        "react": "^16.8.6 || ^17.0.0",
         "react-native": ">=0.60.0"
     }
 }


### PR DESCRIPTION
In order to be compatible with React 17 for react-native@0.64 I added react@17 as peer dependency to aid dependency resolution to work correct. 