### PR TITLE
Include `enableDiskCaching` static method

### DIFF
--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewModule.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewModule.java
@@ -53,4 +53,9 @@ class FastImageViewModule extends ReactContextBaseJavaModule {
             }
         });
     }
+
+    @ReactMethod
+    public void enableDiskCaching() {
+        // does nothing on android
+    }
 }

--- a/ios/FastImage/FFFastImageViewManager.m
+++ b/ios/FastImage/FFFastImageViewManager.m
@@ -1,6 +1,8 @@
 #import "FFFastImageViewManager.h"
 #import "FFFastImageView.h"
-
+  
+#import <SDWebImage/SDImageCache.h>
+#import <SDWebImage/SDWebImageManager.h>
 #import <SDWebImage/SDWebImagePrefetcher.h>
 
 @implementation FFFastImageViewManager
@@ -32,6 +34,24 @@ RCT_EXPORT_METHOD(preload:(nonnull NSArray<FFFastImageSource *> *)sources)
     }];
 
     [[SDWebImagePrefetcher sharedImagePrefetcher] prefetchURLs:urls];
+}
+
+RCT_EXPORT_METHOD(enableDiskCaching)
+{
+    NSUInteger m1 = [NSProcessInfo processInfo].physicalMemory;
+
+    SDImageCache *cache = [SDImageCache sharedImageCache];
+    SDWebImageManager *manager = [SDWebImageManager sharedManager];
+    
+    cache.config.maxMemoryCost = m1 / 4;
+    cache.config.maxDiskAge = 3600 * 24 * 7;
+    cache.config.shouldCacheImagesInMemory = NO; 
+    cache.config.shouldUseWeakMemoryCache = NO; 
+    cache.config.diskCacheReadingOptions = NSDataReadingMappedIfSafe;
+    manager.optionsProcessor = [SDWebImageOptionsProcessor optionsProcessorWithBlock:^SDWebImageOptionsResult * _Nullable(NSURL * _Nullable url, SDWebImageOptions options, SDWebImageContext * _Nullable context) {
+         options |= SDWebImageAvoidDecodeImage;
+         return [[SDWebImageOptionsResult alloc] initWithOptions:options context:context];
+     }];
 }
 
 @end

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -41,6 +41,7 @@ export type Priorities = $Values<Priority>
 export type CacheControls = $Values<CacheControl>
 
 export type PreloadFn = (sources: Array<FastImageSource>) => void
+export type EnableDiskCachingFn = () => void
 export type FastImageSource = {
     uri?: string,
     headers?: Object,
@@ -68,4 +69,5 @@ declare export default class FastImage extends React$Component<FastImageProps> {
     static priority: Priority;
     static cacheControl: CacheControl;
     static preload: PreloadFn;
+    static enableDiskCaching: EnableDiskCachingFn;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -203,6 +203,7 @@ interface FastImageStaticProperties {
     priority: typeof priority
     cacheControl: typeof cacheControl
     preload: (sources: Source[]) => void
+    enableDiskCaching: () => void
 }
 
 const FastImage: React.ComponentType<FastImageProps> &
@@ -216,6 +217,9 @@ FastImage.priority = priority
 
 FastImage.preload = (sources: Source[]) =>
     FastImageViewNativeModule.preload(sources)
+
+FastImage.enableDiskCaching = () =>
+    FastImageViewNativeModule.enableDiskCaching()
 
 const styles = StyleSheet.create({
     imageContainer: {


### PR DESCRIPTION
On older IOS devices with low memory often face app crash "out of memory" issue.
This gives an option to choose caching on disk instead of memory to avoid such problem

simply added `enableDiskCaching` static method to the package