### PR TITLE
Add export to FastImageStaticProperties

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -198,7 +198,7 @@ const FastImageComponent: React.ComponentType<FastImageProps> = forwardRef(
 
 FastImageComponent.displayName = 'FastImage'
 
-interface FastImageStaticProperties {
+export interface FastImageStaticProperties {
     resizeMode: typeof resizeMode
     priority: typeof priority
     cacheControl: typeof cacheControl


### PR DESCRIPTION
Hi everyone. I'd like to introduce this `export` to avoid having this message when using this lib with styled-components/native.

```
Exported variable 'ImageControl' has or is using name 'FastImageStaticProperties' from external module "/Users/test/Projects/p1/node_modules/react-native-fast-image/dist/index" but cannot be named.
```

Code that triggers the error message:
```tsx
import FastImage, { FastImageProps } from 'react-native-fast-image';
import styled from 'styled-components/native';

export const ImageControl = styled(FastImage)<FastImageProps>``
```

Regards,