### PR TITLE
feat: add a dependency with a glide-plugin to support APNG, animated WebP on Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -65,4 +65,5 @@ dependencies {
     implementation "com.github.bumptech.glide:glide:${glideVersion}"
     implementation "com.github.bumptech.glide:okhttp3-integration:${glideVersion}"
     annotationProcessor "com.github.bumptech.glide:compiler:${glideVersion}"
+    implementation 'com.github.penfeizhou.android.animation:glide-plugin:2.12.0'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -65,5 +65,5 @@ dependencies {
     implementation "com.github.bumptech.glide:glide:${glideVersion}"
     implementation "com.github.bumptech.glide:okhttp3-integration:${glideVersion}"
     annotationProcessor "com.github.bumptech.glide:compiler:${glideVersion}"
-    implementation 'com.github.penfeizhou.android.animation:glide-plugin:2.12.0'
+    implementation 'com.github.penfeizhou.android.animation:glide-plugin:2.17.0'
 }


### PR DESCRIPTION
In #673, @ardalahmet provides a simple way to add support of APNG on Android.

Since glide doesn't support APNG, `react-native-fast-image` hasn't supported APNG on Android.
However @penfeizhou's [APNG4Android](https://github.com/penfeizhou/APNG4Android) provides a glide-plugin to support animation easily. It supports `gif`, `APNG`, and `Animated WebP`.

This PR simply applies @ardalahmet's suggestion and add it to Android's gradle dependency.

Should there be any concern of adding the glide plugin?

closes #92 #673 

related PR: #703 #542