### PR TITLE
Update SDWebImage to the latest version (5.12.1)

### DIFF
--- a/RNFastImage.podspec
+++ b/RNFastImage.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/**/*.{h,m}"
 
   s.dependency 'React-Core'
-  s.dependency 'SDWebImage', '~> 5.11.1'
+  s.dependency 'SDWebImage', '~> 5.12.1'
   s.dependency 'SDWebImageWebPCoder', '~> 0.8.4'
 end


### PR DESCRIPTION
We need this specifically to fix a bug on the latest iPhone and iPad Pros with ProMotion display where the gif does not animate at the right frame rate: https://github.com/SDWebImage/SDWebImage/pull/3280