### PR TITLE
Rollback resizeMode.CENTER_INSIDE change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,6 @@ example/android/app/src/main/gen
 
 # build
 react-native-fast-image-*.tgz
-dist/
 
 # coverage reports
 coverage

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewConverter.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewConverter.java
@@ -55,7 +55,7 @@ class FastImageViewConverter {
                 put("contain", ScaleType.FIT_CENTER);
                 put("cover", ScaleType.CENTER_CROP);
                 put("stretch", ScaleType.FIT_XY);
-                put("center", ScaleType.CENTER_INSIDE);
+                put("center", ScaleType.CENTER);
             }};
     
     // Resolve the source uri to a file path that android understands.

--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -1,0 +1,118 @@
+'use strict';
+
+var _extends = require('@babel/runtime/helpers/extends');
+var React = require('react');
+var reactNative = require('react-native');
+
+function _interopDefaultLegacy (e) { return e && typeof e === 'object' && 'default' in e ? e : { 'default': e }; }
+
+var _extends__default = /*#__PURE__*/_interopDefaultLegacy(_extends);
+var React__default = /*#__PURE__*/_interopDefaultLegacy(React);
+
+const FastImageViewNativeModule = reactNative.NativeModules.FastImageView;
+const resizeMode = {
+  contain: 'contain',
+  cover: 'cover',
+  stretch: 'stretch',
+  center: 'center'
+};
+const priority = {
+  low: 'low',
+  normal: 'normal',
+  high: 'high'
+};
+const cacheControl = {
+  // Ignore headers, use uri as cache key, fetch only if not in cache.
+  immutable: 'immutable',
+  // Respect http headers, no aggressive caching.
+  web: 'web',
+  // Only load from cache.
+  cacheOnly: 'cacheOnly'
+};
+
+function FastImageBase({
+  source,
+  tintColor,
+  onLoadStart,
+  onProgress,
+  onLoad,
+  onError,
+  onLoadEnd,
+  style,
+  fallback,
+  children,
+  // eslint-disable-next-line no-shadow
+  resizeMode = 'cover',
+  forwardedRef,
+  ...props
+}) {
+  if (fallback) {
+    const cleanedSource = { ...source
+    };
+    delete cleanedSource.cache;
+    const resolvedSource = reactNative.Image.resolveAssetSource(cleanedSource);
+    return /*#__PURE__*/React__default['default'].createElement(reactNative.View, {
+      style: [styles.imageContainer, style],
+      ref: forwardedRef
+    }, /*#__PURE__*/React__default['default'].createElement(reactNative.Image, _extends__default['default']({}, props, {
+      style: reactNative.StyleSheet.absoluteFill,
+      source: resolvedSource,
+      onLoadStart: onLoadStart,
+      onProgress: onProgress,
+      onLoad: onLoad,
+      onError: onError,
+      onLoadEnd: onLoadEnd,
+      resizeMode: resizeMode
+    })), children);
+  }
+
+  const resolvedSource = reactNative.Image.resolveAssetSource(source);
+  return /*#__PURE__*/React__default['default'].createElement(reactNative.View, {
+    style: [styles.imageContainer, style],
+    ref: forwardedRef
+  }, /*#__PURE__*/React__default['default'].createElement(FastImageView, _extends__default['default']({}, props, {
+    tintColor: tintColor,
+    style: reactNative.StyleSheet.absoluteFill,
+    source: resolvedSource,
+    onFastImageLoadStart: onLoadStart,
+    onFastImageProgress: onProgress,
+    onFastImageLoad: onLoad,
+    onFastImageError: onError,
+    onFastImageLoadEnd: onLoadEnd,
+    resizeMode: resizeMode
+  })), children);
+}
+
+const FastImageMemo = /*#__PURE__*/React.memo(FastImageBase);
+const FastImageComponent = /*#__PURE__*/React.forwardRef((props, ref) => /*#__PURE__*/React__default['default'].createElement(FastImageMemo, _extends__default['default']({
+  forwardedRef: ref
+}, props)));
+FastImageComponent.displayName = 'FastImage';
+const FastImage = FastImageComponent;
+FastImage.resizeMode = resizeMode;
+FastImage.cacheControl = cacheControl;
+FastImage.priority = priority;
+
+FastImage.preload = sources => FastImageViewNativeModule.preload(sources);
+
+FastImage.clearMemoryCache = () => FastImageViewNativeModule.clearMemoryCache();
+
+FastImage.clearDiskCache = () => FastImageViewNativeModule.clearDiskCache();
+
+const styles = reactNative.StyleSheet.create({
+  imageContainer: {
+    overflow: 'hidden'
+  }
+}); // Types of requireNativeComponent are not correct.
+
+const FastImageView = reactNative.requireNativeComponent('FastImageView', FastImage, {
+  nativeOnly: {
+    onFastImageLoadStart: true,
+    onFastImageProgress: true,
+    onFastImageLoad: true,
+    onFastImageError: true,
+    onFastImageLoadEnd: true
+  }
+});
+
+module.exports = FastImage;

--- a/dist/index.cjs.js.flow
+++ b/dist/index.cjs.js.flow
@@ -1,0 +1,73 @@
+// @flow
+
+import type { ViewProps } from 'react-native/Libraries/Components/View/ViewPropTypes'
+import type { SyntheticEvent } from 'react-native/Libraries/Types/CoreEventTypes'
+
+export type OnLoadEvent = SyntheticEvent<
+    $ReadOnly<{
+        width: number,
+        height: number,
+    }>,
+>
+
+export type OnProgressEvent = SyntheticEvent<
+    $ReadOnly<{|
+        loaded: number,
+        total: number,
+    |}>,
+>
+
+export type ResizeMode = $ReadOnly<{|
+    contain: 'contain',
+    cover: 'cover',
+    stretch: 'stretch',
+    center: 'center',
+|}>
+
+export type Priority = $ReadOnly<{|
+    low: 'low',
+    normal: 'normal',
+    high: 'high',
+|}>
+
+export type CacheControl = $ReadOnly<{|
+    immutable: 'immutable',
+    web: 'web',
+    cacheOnly: 'cacheOnly',
+|}>
+
+export type ResizeModes = $Values<ResizeMode>
+export type Priorities = $Values<Priority>
+export type CacheControls = $Values<CacheControl>
+
+export type PreloadFn = (sources: Array<FastImageSource>) => void
+export type FastImageSource = {
+    uri?: string,
+    headers?: Object,
+    priority?: Priorities,
+    cache?: CacheControls,
+}
+
+export type FastImageProps = $ReadOnly<{|
+    ...ViewProps,
+    onError?: ?() => void,
+    onLoad?: ?(event: OnLoadEvent) => void,
+    onLoadEnd?: ?() => void,
+    onLoadStart?: ?() => void,
+    onProgress?: ?(event: OnProgressEvent) => void,
+
+    source: FastImageSource | number,
+
+    resizeMode?: ?ResizeModes,
+    fallback?: ?boolean,
+    testID?: ?string,
+|}>
+
+declare export default class FastImage extends React$Component<FastImageProps> {
+    static resizeMode: ResizeMode;
+    static priority: Priority;
+    static cacheControl: CacheControl;
+    static preload: PreloadFn;
+    static clearMemoryCache: () => Promise<void>;
+    static clearDiskCache: () => Promise<void>;
+}

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,111 @@
+import _extends from '@babel/runtime/helpers/extends';
+import React, { forwardRef, memo } from 'react';
+import { NativeModules, StyleSheet, requireNativeComponent, Image, View } from 'react-native';
+
+const FastImageViewNativeModule = NativeModules.FastImageView;
+const resizeMode = {
+  contain: 'contain',
+  cover: 'cover',
+  stretch: 'stretch',
+  center: 'center'
+};
+const priority = {
+  low: 'low',
+  normal: 'normal',
+  high: 'high'
+};
+const cacheControl = {
+  // Ignore headers, use uri as cache key, fetch only if not in cache.
+  immutable: 'immutable',
+  // Respect http headers, no aggressive caching.
+  web: 'web',
+  // Only load from cache.
+  cacheOnly: 'cacheOnly'
+};
+
+function FastImageBase({
+  source,
+  tintColor,
+  onLoadStart,
+  onProgress,
+  onLoad,
+  onError,
+  onLoadEnd,
+  style,
+  fallback,
+  children,
+  // eslint-disable-next-line no-shadow
+  resizeMode = 'cover',
+  forwardedRef,
+  ...props
+}) {
+  if (fallback) {
+    const cleanedSource = { ...source
+    };
+    delete cleanedSource.cache;
+    const resolvedSource = Image.resolveAssetSource(cleanedSource);
+    return /*#__PURE__*/React.createElement(View, {
+      style: [styles.imageContainer, style],
+      ref: forwardedRef
+    }, /*#__PURE__*/React.createElement(Image, _extends({}, props, {
+      style: StyleSheet.absoluteFill,
+      source: resolvedSource,
+      onLoadStart: onLoadStart,
+      onProgress: onProgress,
+      onLoad: onLoad,
+      onError: onError,
+      onLoadEnd: onLoadEnd,
+      resizeMode: resizeMode
+    })), children);
+  }
+
+  const resolvedSource = Image.resolveAssetSource(source);
+  return /*#__PURE__*/React.createElement(View, {
+    style: [styles.imageContainer, style],
+    ref: forwardedRef
+  }, /*#__PURE__*/React.createElement(FastImageView, _extends({}, props, {
+    tintColor: tintColor,
+    style: StyleSheet.absoluteFill,
+    source: resolvedSource,
+    onFastImageLoadStart: onLoadStart,
+    onFastImageProgress: onProgress,
+    onFastImageLoad: onLoad,
+    onFastImageError: onError,
+    onFastImageLoadEnd: onLoadEnd,
+    resizeMode: resizeMode
+  })), children);
+}
+
+const FastImageMemo = /*#__PURE__*/memo(FastImageBase);
+const FastImageComponent = /*#__PURE__*/forwardRef((props, ref) => /*#__PURE__*/React.createElement(FastImageMemo, _extends({
+  forwardedRef: ref
+}, props)));
+FastImageComponent.displayName = 'FastImage';
+const FastImage = FastImageComponent;
+FastImage.resizeMode = resizeMode;
+FastImage.cacheControl = cacheControl;
+FastImage.priority = priority;
+
+FastImage.preload = sources => FastImageViewNativeModule.preload(sources);
+
+FastImage.clearMemoryCache = () => FastImageViewNativeModule.clearMemoryCache();
+
+FastImage.clearDiskCache = () => FastImageViewNativeModule.clearDiskCache();
+
+const styles = StyleSheet.create({
+  imageContainer: {
+    overflow: 'hidden'
+  }
+}); // Types of requireNativeComponent are not correct.
+
+const FastImageView = requireNativeComponent('FastImageView', FastImage, {
+  nativeOnly: {
+    onFastImageLoadStart: true,
+    onFastImageProgress: true,
+    onFastImageLoad: true,
+    onFastImageError: true,
+    onFastImageLoadEnd: true
+  }
+});
+
+export default FastImage;

--- a/dist/index.js.flow
+++ b/dist/index.js.flow
@@ -1,0 +1,73 @@
+// @flow
+
+import type { ViewProps } from 'react-native/Libraries/Components/View/ViewPropTypes'
+import type { SyntheticEvent } from 'react-native/Libraries/Types/CoreEventTypes'
+
+export type OnLoadEvent = SyntheticEvent<
+    $ReadOnly<{
+        width: number,
+        height: number,
+    }>,
+>
+
+export type OnProgressEvent = SyntheticEvent<
+    $ReadOnly<{|
+        loaded: number,
+        total: number,
+    |}>,
+>
+
+export type ResizeMode = $ReadOnly<{|
+    contain: 'contain',
+    cover: 'cover',
+    stretch: 'stretch',
+    center: 'center',
+|}>
+
+export type Priority = $ReadOnly<{|
+    low: 'low',
+    normal: 'normal',
+    high: 'high',
+|}>
+
+export type CacheControl = $ReadOnly<{|
+    immutable: 'immutable',
+    web: 'web',
+    cacheOnly: 'cacheOnly',
+|}>
+
+export type ResizeModes = $Values<ResizeMode>
+export type Priorities = $Values<Priority>
+export type CacheControls = $Values<CacheControl>
+
+export type PreloadFn = (sources: Array<FastImageSource>) => void
+export type FastImageSource = {
+    uri?: string,
+    headers?: Object,
+    priority?: Priorities,
+    cache?: CacheControls,
+}
+
+export type FastImageProps = $ReadOnly<{|
+    ...ViewProps,
+    onError?: ?() => void,
+    onLoad?: ?(event: OnLoadEvent) => void,
+    onLoadEnd?: ?() => void,
+    onLoadStart?: ?() => void,
+    onProgress?: ?(event: OnProgressEvent) => void,
+
+    source: FastImageSource | number,
+
+    resizeMode?: ?ResizeModes,
+    fallback?: ?boolean,
+    testID?: ?string,
+|}>
+
+declare export default class FastImage extends React$Component<FastImageProps> {
+    static resizeMode: ResizeMode;
+    static priority: Priority;
+    static cacheControl: CacheControl;
+    static preload: PreloadFn;
+    static clearMemoryCache: () => Promise<void>;
+    static clearDiskCache: () => Promise<void>;
+}


### PR DESCRIPTION
Hi,

I've noticed that in one of the prior PR's, androids' CENTER resizeMode was changed to CENTER_INSIDE, however, this will upscale the image. The default behavior of the center resizeMode should be to not upscale the image, this is in accordance with the behavior of React-Image.