### PR TITLE
Revert CENTER_INSIDE resizeMode

### DIFF
--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewConverter.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewConverter.java
@@ -55,7 +55,7 @@ class FastImageViewConverter {
                 put("contain", ScaleType.FIT_CENTER);
                 put("cover", ScaleType.CENTER_CROP);
                 put("stretch", ScaleType.FIT_XY);
-                put("center", ScaleType.CENTER_INSIDE);
+                put("center", ScaleType.CENTER);
             }};
     
     // Resolve the source uri to a file path that android understands.


### PR DESCRIPTION
Apparently resizeMode for 'center' appears to map to CENTER_INSIDE on android. However react-image doesn't upscale the image when using resizeMode.center, using CENTER_INSIDE however, will upscale the image.