### PR TITLE
added null check in registry to fix the crash

### DIFF
--- a/android/src/main/java/com/dylanvann/fastimage/FastImageOkHttpProgressGlideModule.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageOkHttpProgressGlideModule.java
@@ -47,6 +47,9 @@ public class FastImageOkHttpProgressGlideModule extends LibraryGlideModule {
                 .build();
         OkHttpUrlLoader.Factory factory = new OkHttpUrlLoader.Factory(client);
         registry.replace(GlideUrl.class, InputStream.class, factory);
+        if(registry !=null){
+            registry.replace(GlideUrl.class, InputStream.class, factory);
+        }
     }
 
     private static Interceptor createInterceptor(final ResponseProgressListener listener) {


### PR DESCRIPTION
In nexus 5x(6.0.1) device, the app crashes.
Added a null check to avoid the crash from happening
