### PR TITLE
Add option to disable interpolation when resizing small images

### DIFF
--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewConverter.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewConverter.java
@@ -13,6 +13,7 @@ import com.bumptech.glide.Priority;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.bumptech.glide.load.model.Headers;
 import com.bumptech.glide.load.model.LazyHeaders;
+import com.bumptech.glide.load.resource.bitmap.DownsampleStrategy;
 import com.bumptech.glide.request.RequestOptions;
 import com.bumptech.glide.signature.ApplicationVersionSignature;
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
@@ -84,6 +85,8 @@ class FastImageViewConverter {
         final Priority priority = FastImageViewConverter.getPriority(source);
         // Get cache control method.
         final FastImageCacheControl cacheControl = FastImageViewConverter.getCacheControl(source);
+        // Get pixel perfect.
+        final boolean pixelPerfect = FastImageViewConverter.getPixelPerfect(source);
         DiskCacheStrategy diskCacheStrategy = DiskCacheStrategy.AUTOMATIC;
         boolean onlyFromCache = false;
         boolean skipMemoryCache = false;
@@ -108,6 +111,13 @@ class FastImageViewConverter {
                 .priority(priority)
                 .placeholder(TRANSPARENT_DRAWABLE);
 
+        if (pixelPerfect) {
+            options = options
+                    .downsample(DownsampleStrategy.NONE)
+                    .encodeQuality(100)
+                    .dontTransform();
+        }
+
         if (imageSource.isResource()) {
             // Every local resource (drawable) in Android has its own unique numeric id, which are
             // generated at build time. Although these ids are unique, they are not guaranteed unique
@@ -131,6 +141,16 @@ class FastImageViewConverter {
 
     static ScaleType getScaleType(String propValue) {
         return getValue("resizeMode", "cover", FAST_IMAGE_RESIZE_MODE_MAP, propValue);
+    }
+
+    static boolean getPixelPerfect(ReadableMap source) {
+        Boolean propValue;
+        try {
+            propValue = source != null ? source.getBoolean("pixelPerfect") : null;
+        } catch (NoSuchKeyException e) {
+            propValue = null;
+        }
+        return propValue != null && propValue;
     }
 
     private static <T> T getValue(String propName, String defaultPropValue, Map<String, T> map, String propValue) {

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewWithUrl.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewWithUrl.java
@@ -156,4 +156,12 @@ class FastImageViewWithUrl extends AppCompatImageView {
             requestManager.clear(this);
         }
     }
+
+    @Override
+    public void setImageDrawable(@Nullable Drawable drawable) {
+        super.setImageDrawable(drawable);
+        if (drawable != null) {
+            drawable.setFilterBitmap(!FastImageViewConverter.getPixelPerfect(mSource));
+        }
+    }
 }

--- a/ios/FastImage/FFFastImageSource.h
+++ b/ios/FastImage/FFFastImageSource.h
@@ -24,10 +24,13 @@ typedef NS_ENUM(NSInteger, FFFCacheControl) {
 @property (nonatomic) NSDictionary *headers;
 // cache control mode
 @property (nonatomic) FFFCacheControl cacheControl;
+// pixel perfect, to disable interpolation
+@property (nonatomic) BOOL pixelPerfect;
 
 - (instancetype)initWithURL:(NSURL *)url
                    priority:(FFFPriority)priority
                     headers:(NSDictionary *)headers
-               cacheControl:(FFFCacheControl)cacheControl;
+               cacheControl:(FFFCacheControl)cacheControl
+               pixelPerfect:(BOOL)pixelPerfect;
 
 @end

--- a/ios/FastImage/FFFastImageSource.m
+++ b/ios/FastImage/FFFastImageSource.m
@@ -6,6 +6,7 @@
                    priority:(FFFPriority)priority
                     headers:(NSDictionary *)headers
                cacheControl:(FFFCacheControl)cacheControl
+               pixelPerfect:(BOOL)pixelPerfect
 {
     self = [super init];
     if (self) {
@@ -13,6 +14,7 @@
         _priority = priority;
         _headers = headers;
         _cacheControl = cacheControl;
+        _pixelPerfect = pixelPerfect;
     }
     return self;
 }

--- a/ios/FastImage/FFFastImageView.m
+++ b/ios/FastImage/FFFastImageView.m
@@ -187,6 +187,15 @@
                 break;
         }
 
+        // Set pixel perfect.
+        if (_source.pixelPerfect) {
+            super.layer.minificationFilter = kCAFilterNearest;
+            super.layer.magnificationFilter = kCAFilterNearest;
+        } else {
+            super.layer.minificationFilter = kCAFilterLinear;
+            super.layer.magnificationFilter = kCAFilterLinear;
+        }
+
         if (self.onFastImageLoadStart) {
             self.onFastImageLoadStart(@{});
             self.hasSentOnLoadStart = YES;

--- a/ios/FastImage/RCTConvert+FFFastImage.m
+++ b/ios/FastImage/RCTConvert+FFFastImage.m
@@ -42,8 +42,10 @@ RCT_ENUM_CONVERTER(FFFCacheControl, (@{
             headers = nil;
         }
     }
+
+    BOOL pixelPerfect = [self BOOL:json[@"pixelPerfect"]];
     
-    FFFastImageSource *imageSource = [[FFFastImageSource alloc] initWithURL:uri priority:priority headers:headers cacheControl:cacheControl];
+    FFFastImageSource *imageSource = [[FFFastImageSource alloc] initWithURL:uri priority:priority headers:headers cacheControl:cacheControl pixelPerfect:pixelPerfect];
     
     return imageSource;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -49,6 +49,12 @@ export type Source = {
     headers?: { [key: string]: string }
     priority?: Priority
     cache?: Cache
+
+    /**
+     * If true, images will not have any interpolation/filtering applied to them when scaled.
+     */
+    pixelPerfect?: boolean
+
 }
 
 export interface OnLoadEvent {
@@ -173,6 +179,7 @@ function FastImageBase({
     if (fallback) {
         const cleanedSource = { ...(source as any) }
         delete cleanedSource.cache
+        delete cleanedSource.pixelPerfect
         const resolvedSource = Image.resolveAssetSource(cleanedSource)
 
         return (


### PR DESCRIPTION
Fixes #926

I opted to add pixelPerfect to source, since it makes the android implementation much easier. It may make more sense to add it to `FastImageProps`, but then I'm not sure how we would access it from Android's `getOptions`. (Since downsampling/compression/transforming need to be disabled)

It works on my iOS device and sim, and my Android emulator (do not have a physical Android device). I'm still pretty new to React Native, Android, and iOS development so let me know if you see anything wrong!