### PR TITLE
Cache key ignore url params

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,17 @@ const YourImage = () => (
 )
 ```
 
+### Ignoring URL parameters in the cache key
+In cases where your image urls are not stable, for example when using CDN token authentication, you may whish to ignore url parameters when generating cache keys.
+
+In order to do so execute the following as early as possible in your apps lifecycle:
+
+```javascript
+import FastImage from 'react-native-fast-image';
+FastImage.setIgnoreUrlParams(true);
+```
+n.b: This setting is global
+
 ## Are you using Glide already using an AppGlideModule?
 
 -   [Are you using Glide already using an AppGlideModule?](docs/app-glide-module.md) (you might have problems if you don't read this)

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageSource.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageSource.java
@@ -17,6 +17,7 @@ public class FastImageSource extends ImageSource {
     private static final String ANDROID_RESOURCE_SCHEME = "android.resource";
     private static final String ANDROID_CONTENT_SCHEME = "content";
     private static final String LOCAL_FILE_SCHEME = "file";
+    private Boolean shouldIgnoreUrlParams = false;
     private final Headers mHeaders;
     private Uri mUri;
 
@@ -41,17 +42,21 @@ public class FastImageSource extends ImageSource {
     }
 
     public FastImageSource(Context context, String source) {
-        this(context, source, null);
+        this(context, source, null, null);
     }
 
-    public FastImageSource(Context context, String source, @Nullable Headers headers) {
-        this(context, source, 0.0d, 0.0d, headers);
+    public FastImageSource(Context context, String source, @Nullable Headers headers, @Nullable Boolean shouldIgnoreUrlParams) {
+        this(context, source, 0.0d, 0.0d, headers,shouldIgnoreUrlParams);
     }
 
-    public FastImageSource(Context context, String source, double width, double height, @Nullable Headers headers) {
+    public FastImageSource(Context context, String source, double width, double height, @Nullable Headers headers, @Nullable Boolean shouldIgnoreUrlParams) {
         super(context, source, width, height);
         mHeaders = headers == null ? Headers.DEFAULT : headers;
         mUri = super.getUri();
+
+        if (shouldIgnoreUrlParams) {
+            this.shouldIgnoreUrlParams = shouldIgnoreUrlParams;
+        }
 
         if (isResource() && TextUtils.isEmpty(mUri.toString())) {
             throw new Resources.NotFoundException("Local Resource Not Found. Resource: '" + getSource() + "'.");
@@ -107,6 +112,10 @@ public class FastImageSource extends ImageSource {
     }
 
     public GlideUrl getGlideUrl() {
-        return new GlideUrl(getUri().toString(), getHeaders());
+        if (this.shouldIgnoreUrlParams) {
+            return new GlideUrlIgnoreUrlParams(getUri().toString());
+        } else {
+            return new GlideUrl(getUri().toString(), getHeaders());
+        }
     }
 }

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewConverter.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewConverter.java
@@ -52,10 +52,10 @@ class FastImageViewConverter {
 
     // Resolve the source uri to a file path that android understands.
     static @Nullable
-    FastImageSource getImageSource(Context context, @Nullable ReadableMap source) {
+    FastImageSource getImageSource(Context context, @Nullable ReadableMap source, Boolean shouldIgnoreUrlParams) {
         return source == null
                 ? null
-                : new FastImageSource(context, source.getString("uri"), getHeaders(source));
+                : new FastImageSource(context, source.getString("uri"), getHeaders(source), shouldIgnoreUrlParams);
     }
 
     static Headers getHeaders(ReadableMap source) {

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
@@ -61,6 +61,11 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
         view.setSource(source);
     }
 
+    @ReactProp(name = "shouldIgnoreParams")
+    public void setShouldIgnoreUrlParams(FastImageViewWithUrl view, @Nullable Boolean shouldIgnoreParams) {
+        view.setShouldIgnoreUrlParams(shouldIgnoreParams);
+    }
+
     @ReactProp(name = "defaultSource")
     public void setDefaultSource(FastImageViewWithUrl view, @Nullable String source) {
         view.setDefaultSource(

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewModule.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewModule.java
@@ -29,7 +29,7 @@ class FastImageViewModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void preload(final ReadableArray sources) {
+    public void preload(final ReadableArray sources, Boolean shouldIgnoreUrlParams) {
         final Activity activity = getCurrentActivity();
         if (activity == null) return;
         activity.runOnUiThread(new Runnable() {
@@ -37,7 +37,7 @@ class FastImageViewModule extends ReactContextBaseJavaModule {
             public void run() {
                 for (int i = 0; i < sources.size(); i++) {
                     final ReadableMap source = sources.getMap(i);
-                    final FastImageSource imageSource = FastImageViewConverter.getImageSource(activity, source);
+                    final FastImageSource imageSource = FastImageViewConverter.getImageSource(activity, source, shouldIgnoreUrlParams);
 
                     Glide
                             .with(activity.getApplicationContext())

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewWithUrl.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewWithUrl.java
@@ -30,6 +30,7 @@ class FastImageViewWithUrl extends AppCompatImageView {
     private boolean mNeedsReload = false;
     private ReadableMap mSource = null;
     private Drawable mDefaultSource = null;
+    private Boolean shouldIgnoreUrlParams = false;
 
     public GlideUrl glideUrl;
 
@@ -40,6 +41,12 @@ class FastImageViewWithUrl extends AppCompatImageView {
     public void setSource(@Nullable ReadableMap source) {
         mNeedsReload = true;
         mSource = source;
+    }
+
+    public void setShouldIgnoreUrlParams(@Nullable Boolean shouldIgnore) {
+        if (shouldIgnore){
+          this.shouldIgnoreUrlParams = shouldIgnore;
+        }
     }
 
     public void setDefaultSource(@Nullable Drawable source) {
@@ -77,7 +84,7 @@ class FastImageViewWithUrl extends AppCompatImageView {
         }
 
         //final GlideUrl glideUrl = FastImageViewConverter.getGlideUrl(view.getContext(), mSource);
-        final FastImageSource imageSource = FastImageViewConverter.getImageSource(getContext(), mSource);
+        final FastImageSource imageSource = FastImageViewConverter.getImageSource(getContext(), mSource, shouldIgnoreUrlParams);
 
         if (imageSource != null && imageSource.getUri().toString().length() == 0) {
             ThemedReactContext context = (ThemedReactContext) getContext();

--- a/android/src/main/java/com/dylanvann/fastimage/GlideUrlIgnoreUrlParams.java
+++ b/android/src/main/java/com/dylanvann/fastimage/GlideUrlIgnoreUrlParams.java
@@ -1,0 +1,18 @@
+package com.dylanvann.fastimage;
+import com.bumptech.glide.load.model.GlideUrl;
+
+public class GlideUrlIgnoreUrlParams extends GlideUrl {
+    public GlideUrlIgnoreUrlParams(String url) {
+        super(url);
+    }
+
+    @Override
+    public String getCacheKey() {
+        String url = toStringUrl();
+        if (url.contains("?")) {
+            return url.substring(0, url.lastIndexOf("?"));
+        } else {
+            return url;
+        }
+    }
+}

--- a/ios/FastImage/FFFastImageViewManager.m
+++ b/ios/FastImage/FFFastImageViewManager.m
@@ -49,4 +49,17 @@ RCT_EXPORT_METHOD(clearDiskCache:(RCTPromiseResolveBlock)resolve reject:(RCTProm
     }];
 }
 
+RCT_EXPORT_METHOD(setIgnoreUrlParams:(BOOL)shouldIgnore)
+{
+  SDWebImageCacheKeyFilter *cacheKeyFilter = [SDWebImageCacheKeyFilter cacheKeyFilterWithBlock:^NSString * _Nullable(NSURL * _Nonnull url) {
+      NSURLComponents *urlComponents = [[NSURLComponents alloc] initWithURL:url resolvingAgainstBaseURL:NO];
+      if(shouldIgnore) {
+        urlComponents.query = nil;
+      }
+      return urlComponents.URL.absoluteString;
+  }];
+
+  SDWebImageManager.sharedManager.cacheKeyFilter = cacheKeyFilter;
+}
+
 @end

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -80,6 +80,10 @@ export interface ImageStyle extends FlexStyle, TransformsStyle, ShadowStyleIOS {
     opacity?: number
 }
 
+interface FastImageInternalProps{
+  shouldIgnoreParams?: boolean;
+}
+
 export interface FastImageProps extends AccessibilityProps, ViewProps {
     source?: Source | ImageRequireSource
     defaultSource?: ImageRequireSource
@@ -169,7 +173,7 @@ function FastImageBase({
     resizeMode = 'cover',
     forwardedRef,
     ...props
-}: FastImageProps & { forwardedRef: React.Ref<any> }) {
+}: FastImageProps & FastImageInternalProps & { forwardedRef: React.Ref<any> }) {
     if (fallback) {
         const cleanedSource = { ...(source as any) }
         delete cleanedSource.cache
@@ -219,9 +223,12 @@ function FastImageBase({
 
 const FastImageMemo = memo(FastImageBase)
 
+/* global variable to store the state for android */
+let shouldIgnoreParams = false;
+
 const FastImageComponent: React.ComponentType<FastImageProps> = forwardRef(
     (props: FastImageProps, ref: React.Ref<any>) => (
-        <FastImageMemo forwardedRef={ref} {...props} />
+        <FastImageMemo forwardedRef={ref} {...props} shouldIgnoreParams={shouldIgnoreParams} />
     ),
 )
 
@@ -232,6 +239,7 @@ export interface FastImageStaticProperties {
     priority: typeof priority
     cacheControl: typeof cacheControl
     preload: (sources: Source[]) => void
+    setIgnoreUrlParams: (shouldIgnore: boolean) => void
     clearMemoryCache: () => Promise<void>
     clearDiskCache: () => Promise<void>
 }
@@ -246,7 +254,14 @@ FastImage.cacheControl = cacheControl
 FastImage.priority = priority
 
 FastImage.preload = (sources: Source[]) =>
-    NativeModules.FastImageView.preload(sources)
+    NativeModules.FastImageView.preload(sources, shouldIgnoreParams)
+
+FastImage.setIgnoreUrlParams = (shouldIgnore: boolean) => {
+    shouldIgnoreParams = shouldIgnore;
+    if (Platform.OS==="ios") {
+        NativeModules.FastImageView.setIgnoreUrlParams(shouldIgnore);
+    }
+}
 
 FastImage.clearMemoryCache = () =>
     NativeModules.FastImageView.clearMemoryCache()

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -253,8 +253,13 @@ FastImage.cacheControl = cacheControl
 
 FastImage.priority = priority
 
-FastImage.preload = (sources: Source[]) =>
-    NativeModules.FastImageView.preload(sources, shouldIgnoreParams)
+FastImage.preload = (sources: Source[]) => {
+    if (Platform.OS === "android") {
+        return NativeModules.FastImageView.preload(sources, shouldIgnoreParams)
+    } else {
+        return NativeModules.FastImageView.preload(sources)
+    }
+}
 
 FastImage.setIgnoreUrlParams = (shouldIgnore: boolean) => {
     shouldIgnoreParams = shouldIgnore;


### PR DESCRIPTION
Adds functionality to exclude url parameters from the cache key genator used by SDWebImage and Glide.

Preview published on npm as `react-native-fast-image-with-url-params-ignore`