### PR TITLE
fix: Android `onLoad` event when view width and height are zero

### DIFF
--- a/ReactNativeFastImageExample/android/build.gradle
+++ b/ReactNativeFastImageExample/android/build.gradle
@@ -1,5 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
+def REACT_NATIVE_VERSION = new File(['node', '--print',"JSON.parse(require('fs').readFileSync(require.resolve('react-native/package.json'), 'utf-8')).version"].execute(null, rootDir).text.trim())
+
 buildscript {
     ext {
         buildToolsVersion = "30.0.2"
@@ -34,5 +36,13 @@ allprojects {
 
         google()
         maven { url 'https://www.jitpack.io' }
+
+    }
+
+    configurations.all {
+        resolutionStrategy {
+            // Remove this override in 0.65+, as a proper fix is included in react-native itself.
+            force "com.facebook.react:react-native:" + REACT_NATIVE_VERSION
+        }
     }
 }

--- a/ReactNativeFastImageExample/metro.config.js
+++ b/ReactNativeFastImageExample/metro.config.js
@@ -5,13 +5,45 @@
  * @format
  */
 
+
+
+const path = require('path')
+const escape = require('escape-string-regexp')
+const exclusionList = require('metro-config/src/defaults/exclusionList')
+const pak = require('../package.json')
+
+const root = path.resolve(__dirname, '..')
+
+const modules = Object.keys({
+  ...pak.peerDependencies,
+})
+
 module.exports = {
-    transformer: {
-        getTransformOptions: async () => ({
-            transform: {
-                experimentalImportSupport: false,
-                inlineRequires: true,
-            },
-        }),
-    },
+  projectRoot: __dirname,
+  watchFolders: [root],
+
+  // We need to make sure that only one version is loaded for peerDependencies
+  // So we block them at the root, and alias them to the versions in example's node_modules
+  resolver: {
+    blacklistRE: exclusionList(
+      modules.map(
+        (m) =>
+          new RegExp(`^${escape(path.join(root, 'node_modules', m))}\\/.*$`)
+      )
+    ),
+
+    extraNodeModules: modules.reduce((acc, name) => {
+      acc[name] = path.join(__dirname, 'node_modules', name)
+      return acc
+    }, {}),
+  },
+
+  transformer: {
+    getTransformOptions: async () => ({
+      transform: {
+        experimentalImportSupport: false,
+        inlineRequires: true,
+      },
+    }),
+  },
 }

--- a/ReactNativeFastImageExample/src/AutoSizeExample.tsx
+++ b/ReactNativeFastImageExample/src/AutoSizeExample.tsx
@@ -47,6 +47,7 @@ const AutoSizingImage = (props: AutoSizingImageProps) => {
         <FastImage
             {...props}
             onLoad={onLoad}
+            resizeMode={FastImage.resizeMode.contain}
             style={[{ width: props.width, height }, props.style]}
         />
     )

--- a/android/src/main/java/com/dylanvann/fastimage/BitmapSizeDecoder.java
+++ b/android/src/main/java/com/dylanvann/fastimage/BitmapSizeDecoder.java
@@ -1,0 +1,31 @@
+package com.dylanvann.fastimage;
+
+import android.graphics.BitmapFactory;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.bumptech.glide.load.Options;
+import com.bumptech.glide.load.ResourceDecoder;
+import com.bumptech.glide.load.engine.Resource;
+import com.bumptech.glide.load.resource.SimpleResource;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class BitmapSizeDecoder implements ResourceDecoder<InputStream, BitmapFactory.Options> {
+
+    @Override
+    public boolean handles(@NonNull InputStream source, @NonNull Options options) throws IOException {
+        return true;
+    }
+
+    @Nullable
+    @Override
+    public Resource<BitmapFactory.Options> decode(@NonNull InputStream source, int width, int height, @NonNull Options options) throws IOException {
+        BitmapFactory.Options bitmapOptions = new BitmapFactory.Options();
+        bitmapOptions.inJustDecodeBounds = true;
+        BitmapFactory.decodeStream(source, null, bitmapOptions);
+        return new SimpleResource(bitmapOptions);
+    }
+}

--- a/android/src/main/java/com/dylanvann/fastimage/BitmapSizeTranscoder.java
+++ b/android/src/main/java/com/dylanvann/fastimage/BitmapSizeTranscoder.java
@@ -1,0 +1,23 @@
+package com.dylanvann.fastimage;
+
+import android.graphics.BitmapFactory;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.bumptech.glide.load.Options;
+import com.bumptech.glide.load.engine.Resource;
+import com.bumptech.glide.load.resource.SimpleResource;
+import com.bumptech.glide.load.resource.transcode.ResourceTranscoder;
+
+public class BitmapSizeTranscoder implements ResourceTranscoder<BitmapFactory.Options, Size> {
+    @Nullable
+    @Override
+    public Resource<Size> transcode(@NonNull Resource<BitmapFactory.Options> toTranscode, @NonNull Options options) {
+        BitmapFactory.Options bitmap = toTranscode.get();
+        Size size = new Size();
+        size.width = bitmap.outWidth;
+        size.height = bitmap.outHeight;
+        return new SimpleResource(size);
+    }
+}

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageOkHttpProgressGlideModule.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageOkHttpProgressGlideModule.java
@@ -1,6 +1,8 @@
 package com.dylanvann.fastimage;
 
 import android.content.Context;
+import android.graphics.BitmapFactory;
+
 import androidx.annotation.NonNull;
 
 import com.bumptech.glide.Glide;
@@ -47,6 +49,10 @@ public class FastImageOkHttpProgressGlideModule extends LibraryGlideModule {
                 .build();
         OkHttpUrlLoader.Factory factory = new OkHttpUrlLoader.Factory(client);
         registry.replace(GlideUrl.class, InputStream.class, factory);
+
+        // Decoder + Transcoder pair for InputStream -> Size
+        registry.prepend(InputStream.class, BitmapFactory.Options.class, new BitmapSizeDecoder());
+        registry.register(BitmapFactory.Options.class, Size.class, new BitmapSizeTranscoder());
     }
 
     private static Interceptor createInterceptor(final ResponseProgressListener listener) {

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageRequestListener.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageRequestListener.java
@@ -22,13 +22,6 @@ public class FastImageRequestListener implements RequestListener<Drawable> {
         this.key = key;
     }
 
-    private static WritableMap mapFromResource(Drawable resource) {
-        WritableMap resourceData = new WritableNativeMap();
-        resourceData.putInt("width", resource.getIntrinsicWidth());
-        resourceData.putInt("height", resource.getIntrinsicHeight());
-        return resourceData;
-    }
-
     @Override
     public boolean onLoadFailed(@androidx.annotation.Nullable GlideException e, Object model, Target<Drawable> target, boolean isFirstResource) {
         FastImageOkHttpProgressGlideModule.forget(key);
@@ -53,7 +46,6 @@ public class FastImageRequestListener implements RequestListener<Drawable> {
         ThemedReactContext context = (ThemedReactContext) view.getContext();
         RCTEventEmitter eventEmitter = context.getJSModule(RCTEventEmitter.class);
         int viewId = view.getId();
-        eventEmitter.receiveEvent(viewId, REACT_ON_LOAD_EVENT, mapFromResource(resource));
         eventEmitter.receiveEvent(viewId, REACT_ON_LOAD_END_EVENT, new WritableNativeMap());
         return false;
     }

--- a/android/src/main/java/com/dylanvann/fastimage/Size.java
+++ b/android/src/main/java/com/dylanvann/fastimage/Size.java
@@ -1,0 +1,6 @@
+package com.dylanvann.fastimage;
+
+public class Size {
+    int width;
+    int height;
+}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "main": "dist/index.cjs.js",
     "module": "dist/index.js",
     "typings": "dist/index.d.ts",
+    "source": "src/index",
+    "react-native": "src/index",
     "files": [
         "android",
         "!android/build",


### PR DESCRIPTION
Hey @DylanVann 👋

This PR aims to fix an existing issue with the `onLoad` event not firing on Android when the view style's width or height is zero as documented here https://github.com/DylanVann/react-native-fast-image/issues/865. There is a similar PR https://github.com/DylanVann/react-native-fast-image/pull/446 that was opened, but as mentioned in reviews this causes crashes due to the `.override(Target.SIZE_ORIGINAL)` method being applied to Glide. Instead, this PR follows the recommended way of getting the natural image dimensions as documented here in the Glide repo https://github.com/bumptech/glide/issues/781#issuecomment-160953996.

The changes here include:
- Adds a second target of a Size class with the relevant decoder + transcoder to achieve this
- Aligns the `onLoad` method on Android to work in the same way iOS does - reporting the original natural image dimensions
- Some minor dev setup fixes to get the example app up and running

These changes are best tested with the `AutoSize` component in the example app - as you can see setting the width to zero still triggers the `onLoad` event and this example is then rendered correctly.