### PR TITLE
feat: add image enter transition

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ and
 -   [x] Preload images.
 -   [x] GIF support.
 -   [x] Border radius.
+-   [x] Image enter transition.
 
 ## Usage
 
@@ -158,6 +159,24 @@ Headers to load the image with. e.g. `{ Authorization: 'someAuthToken' }`.
 -   `FastImage.resizeMode.center` - Do not scale the image, keep centered.
 
 ---
+
+### `enterTransition?: enum`
+
+-   `FastImage.enterTransition.none` **(Default)** - Transition animation is not used.
+-   `FastImage.enterTransition.fadeIn` - Opacity transition where image goes from transparancy to full opacity.
+-   `FastImage.enterTransition.curlDown` _(iOS only)_ - Page curl transition from left to right.
+-   `FastImage.enterTransition.curlUp` _(iOS only)_ - Page curl transition from top to bottom.
+-   `FastImage.enterTransition.flipTop` - Rotation transition on Y axis from -90° to 0°.
+-   `FastImage.enterTransition.flipBottom` - Rotation transition on Y axis from 90° to 0°.
+-   `FastImage.enterTransition.flipLeft` - Rotation transition on X axis from -90° to 0°.
+-   `FastImage.enterTransition.flipRight` - Rotation transition on X axis from 90° to 0°.
+
+---
+
+### `transitionDuration?: number`
+
+An `enterTransition` duratin in ms.
+Default duration **500ms**
 
 ### `onLoadStart?: () => void`
 

--- a/ReactNativeFastImageExample/package.json
+++ b/ReactNativeFastImageExample/package.json
@@ -29,7 +29,7 @@
         "@react-navigation/native": "^6.0.2",
         "@react-navigation/stack": "^6.0.7",
         "react": "17.0.2",
-        "react-native": "0.65.1",
+        "react-native": "0.65.3",
         "react-native-fast-image": "^8.1.3",
         "react-native-gesture-handler": "^1.6.0",
         "react-native-image-picker": "^4.0.6",

--- a/ReactNativeFastImageExample/src/EnterTransitionExample.tsx
+++ b/ReactNativeFastImageExample/src/EnterTransitionExample.tsx
@@ -9,7 +9,11 @@ export const EnterTransitionExample = () => {
     return (
         <View>
             <Section>
-                <FeatureText text="• Image enter transitions (curlDown, curlUp, fadeIn, flipBottom, flipLeft, flipRight, flipTop)." />
+                <FeatureText
+                    text={`• Image enter transitions (${
+                        Platform.OS === 'ios' ? 'curlDown, curlUp, ' : ''
+                    }fadeIn, flipBottom, flipLeft, flipRight, flipTop).`}
+                />
             </Section>
             {Platform.OS === 'ios' ? (
                 <SectionFlex style={styles.row}>

--- a/ReactNativeFastImageExample/src/EnterTransitionExample.tsx
+++ b/ReactNativeFastImageExample/src/EnterTransitionExample.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { Platform, StyleSheet, View } from 'react-native'
+import FeatureText from './FeatureText'
+import Section from './Section'
+import SectionFlex from './SectionFlex'
+import { TransitionImage } from './TransitionImage'
+
+export const EnterTransitionExample = () => {
+    return (
+        <View>
+            <Section>
+                <FeatureText text="• Image enter transitions (curlDown, curlUp, fadeIn, flipBottom, flipLeft, flipRight, flipTop)." />
+            </Section>
+            {Platform.OS === 'ios' ? (
+                <SectionFlex style={styles.row}>
+                    <TransitionImage enterTransition="curlDown" />
+                    <TransitionImage enterTransition="curlUp" />
+                </SectionFlex>
+            ) : null}
+            <SectionFlex style={styles.row}>
+                <TransitionImage enterTransition="flipTop" />
+                <TransitionImage enterTransition="flipBottom" />
+            </SectionFlex>
+            <SectionFlex style={styles.row}>
+                <TransitionImage enterTransition="flipLeft" />
+                <TransitionImage enterTransition="flipRight" />
+            </SectionFlex>
+            <SectionFlex style={styles.row}>
+                <TransitionImage enterTransition="fadeIn" />
+            </SectionFlex>
+        </View>
+    )
+}
+
+const styles = StyleSheet.create({
+    row: {
+        paddingHorizontal: 10,
+        paddingVertical: 20,
+    },
+})

--- a/ReactNativeFastImageExample/src/FastImageExamples.tsx
+++ b/ReactNativeFastImageExample/src/FastImageExamples.tsx
@@ -12,6 +12,7 @@ import { ResizeModeExample } from './ResizeModeExample'
 import { TintColorExample } from './TintColorExample'
 import { LocalImagesExample } from './LocalImagesExample'
 import { AutoSizeExample } from './AutoSizeExample'
+import { EnterTransitionExample } from './EnterTransitionExample'
 
 const FastImageExample = () => (
     <View style={styles.container}>
@@ -32,6 +33,7 @@ const FastImageExample = () => (
                 <PriorityExample />
                 <GifExample />
                 <BorderRadiusExample />
+                <EnterTransitionExample />
                 <ProgressExample />
                 <PreloadExample />
                 <ResizeModeExample />

--- a/ReactNativeFastImageExample/src/RefreshableImage.tsx
+++ b/ReactNativeFastImageExample/src/RefreshableImage.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { TouchableOpacity } from 'react-native'
+import FastImage, { FastImageProps } from 'react-native-fast-image'
+import { useCacheBust } from './useCacheBust'
+
+interface RefreshableImageProps extends FastImageProps{
+  touchableOpacityStyle?: any
+}
+
+export const RefreshableImage = ({touchableOpacityStyle,...props}: RefreshableImageProps) => {
+    const { query, bust } = useCacheBust('')
+
+    return (
+        <TouchableOpacity onPress={bust} style={touchableOpacityStyle}>
+            <FastImage
+                {...props}
+                style={{flex:1}}
+                source={
+                    typeof props.source === 'number'
+                        ? props.source
+                        : { ...props.source, uri: props.source.uri + query }
+                }
+            />
+        </TouchableOpacity>
+    )
+}

--- a/ReactNativeFastImageExample/src/TransitionImage.tsx
+++ b/ReactNativeFastImageExample/src/TransitionImage.tsx
@@ -1,0 +1,106 @@
+import React, { useState } from 'react'
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+import { FastImageProps } from 'react-native-fast-image'
+import FeatureText from './FeatureText'
+import { RefreshableImage } from './RefreshableImage'
+
+interface TransitionImageProps extends Omit<FastImageProps, 'source'> {}
+
+const IMAGE_URL = 'https://source.unsplash.com/WJXkdAWOWGo/1024x1024'
+
+export const TransitionImage = (props: TransitionImageProps) => {
+    const [transitionDuration, setTransitionDuration] = useState(500)
+
+    return (
+        <View style={styles.container}>
+            <View style={styles.content}>
+                <View
+                    style={{
+                        flexDirection: 'column',
+                        justifyContent: 'space-between',
+                        alignItems: 'center',
+                    }}
+                >
+                    <TouchableOpacity
+                        style={
+                            transitionDuration === 500
+                                ? styles.activeTimeDuration
+                                : styles.timeDuration
+                        }
+                        onPress={() => setTransitionDuration(500)}
+                    >
+                        <Text style={styles.text}>0.5s</Text>
+                    </TouchableOpacity>
+                    <TouchableOpacity
+                        style={
+                            transitionDuration === 1500
+                                ? styles.activeTimeDuration
+                                : styles.timeDuration
+                        }
+                        onPress={() => setTransitionDuration(1500)}
+                    >
+                        <Text style={styles.text}>1.5s</Text>
+                    </TouchableOpacity>
+                    <TouchableOpacity
+                        style={
+                            transitionDuration === 3000
+                                ? styles.activeTimeDuration
+                                : styles.timeDuration
+                        }
+                        onPress={() => setTransitionDuration(3000)}
+                    >
+                        <Text style={styles.text}>3s</Text>
+                    </TouchableOpacity>
+                </View>
+
+                <View style={{ alignItems: 'center' }}>
+                    <FeatureText>{props.enterTransition}</FeatureText>
+                    <RefreshableImage
+                        {...props}
+                        transitionDuration={transitionDuration}
+                        touchableOpacityStyle={styles.image}
+                        source={{ uri: IMAGE_URL }}
+                    />
+                </View>
+            </View>
+        </View>
+    )
+}
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    content: {
+        flex: 1,
+        flexDirection: 'row',
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    activeTimeDuration: {
+        backgroundColor: 'white',
+        margin: 5,
+        padding: 5,
+        borderRadius: 4,
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    timeDuration: {
+        margin: 5,
+        padding: 5,
+        borderRadius: 4,
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    text: {
+        fontSize: 12,
+    },
+    image: {
+        height: 100,
+        aspectRatio: 1,
+        backgroundColor: '#ddd',
+        margin: 10,
+    },
+})

--- a/ReactNativeFastImageExample/yarn.lock
+++ b/ReactNativeFastImageExample/yarn.lock
@@ -5488,9 +5488,9 @@ react-native-codegen@^0.0.7:
     nullthrows "^1.1.1"
 
 react-native-fast-image@^8.1.3:
-  version "8.5.6"
-  resolved "https://registry.yarnpkg.com/react-native-fast-image/-/react-native-fast-image-8.5.6.tgz#3a4062b88bdaa9cf4fc7f7d8e1cd2ee9745d556f"
-  integrity sha512-fkgxxnuvhrrnJQGYDp7H6tk3B9+/V0MK6p6QSGRxlbuQrWqVKPCbikjCgbwmzLDptV0DFlGPtnTkSiRoSqMn0A==
+  version "8.6.3"
+  resolved "https://registry.yarnpkg.com/react-native-fast-image/-/react-native-fast-image-8.6.3.tgz#6edc3f9190092a909d636d93eecbcc54a8822255"
+  integrity sha512-Sdw4ESidXCXOmQ9EcYguNY2swyoWmx53kym2zRsvi+VeFCHEdkO+WG1DK+6W81juot40bbfLNhkc63QnWtesNg==
 
 react-native-gesture-handler@^1.6.0:
   version "1.10.3"
@@ -5556,10 +5556,10 @@ react-native-vector-icons@^8.1.0:
     prop-types "^15.7.2"
     yargs "^16.1.1"
 
-react-native@0.65.1:
-  version "0.65.1"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.65.1.tgz#bd8cd313e0eb8ddcf08e61e3f8b54b7fc31a418c"
-  integrity sha512-0UOVSnlssweQZjuaUtzViCifE/4tXm8oRbxwakopc8GavPu9vLulde145GOw6QVYiOy4iL50f+2XXRdX9NmMeQ==
+react-native@0.65.3:
+  version "0.65.3"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.65.3.tgz#c7bc211c04935b9cc049a280d69b1a401e198f02"
+  integrity sha512-5N93fQ5EJkp9Ys5r2NDCp1x9pmrxPpyQSwLQ3uVwu01XxVSnzCuu4/OzFKr/kgqf0UOxadKl9IWU78XqDIxARA==
   dependencies:
     "@jest/create-cache-key-function" "^27.0.1"
     "@react-native-community/cli" "^6.0.0"

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageEnterTransition.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageEnterTransition.java
@@ -1,0 +1,11 @@
+package com.dylanvann.fastimage;
+
+public enum FastImageEnterTransition {
+    TRANSITION_NONE,
+    FADE_IN,
+    FLIP_BOTTOM,
+    FLIP_LEFT,
+    FLIP_RIGHT,
+    FLIP_TOP
+}
+

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageTransitions.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageTransitions.java
@@ -1,0 +1,71 @@
+package com.dylanvann.fastimage;
+
+import com.bumptech.glide.request.transition.ViewPropertyTransition.Animator;
+import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions;
+import com.bumptech.glide.TransitionOptions;
+import com.bumptech.glide.GenericTransitionOptions;
+import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
+import android.view.View;
+import android.animation.ObjectAnimator;
+import android.animation.PropertyValuesHolder;
+import android.view.animation.DecelerateInterpolator;
+
+public class FastImageTransitions {
+    static final DecelerateInterpolator mInterpolator = new DecelerateInterpolator();
+
+    public static TransitionOptions getEnterTransition(FastImageEnterTransition transition, int duration) {
+        switch (transition) {
+            case FADE_IN:
+                return DrawableTransitionOptions.withCrossFade(duration);
+              
+            case FLIP_LEFT:
+                return GenericTransitionOptions.with(getHorizontalTransition(duration, -90f, 0f));
+
+            case FLIP_RIGHT:
+                return GenericTransitionOptions.with(getHorizontalTransition(duration, 90f, 0));
+              
+            case FLIP_BOTTOM:
+                return GenericTransitionOptions.with(getVerticalTransition(duration, 90f, 0f));
+
+            case FLIP_TOP:
+                return GenericTransitionOptions.with(getVerticalTransition(duration, -90f, 0));
+
+            default:
+                throw new JSApplicationIllegalArgumentException("FastImage, invalid enterTransition argument");
+        }
+    }
+ 
+    private static Animator getVerticalTransition(int duration, float start, float end) {
+        Animator animationObject = new Animator() {  
+            @Override
+            public void animate(View view) {
+                PropertyValuesHolder pvhRotation = PropertyValuesHolder.ofFloat("rotationX", start, end);
+                PropertyValuesHolder pvhScale = PropertyValuesHolder.ofFloat("scaleX", 0.7f, 1f);
+                ObjectAnimator transition = ObjectAnimator.ofPropertyValuesHolder(view, pvhRotation, pvhScale);
+
+                transition.setDuration(duration);
+                transition.setInterpolator(mInterpolator);
+                transition.start();
+            }
+        };
+
+        return animationObject;
+    }
+
+    private static Animator getHorizontalTransition(int duration, float start, float end) {
+        Animator animationObject = new Animator() {  
+            @Override
+            public void animate(View view) {
+                PropertyValuesHolder pvhRotation = PropertyValuesHolder.ofFloat("rotationY", start, end);
+                PropertyValuesHolder pvhScale = PropertyValuesHolder.ofFloat("scaleY", 0.7f, 1f);
+                ObjectAnimator transition = ObjectAnimator.ofPropertyValuesHolder(view, pvhRotation, pvhScale);
+
+                transition.setDuration(duration);
+                transition.setInterpolator(mInterpolator);
+                transition.start();
+            }
+        };
+
+        return animationObject;
+    }
+}

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewConverter.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewConverter.java
@@ -50,6 +50,18 @@ class FastImageViewConverter {
                 put("center", ScaleType.CENTER_INSIDE);
             }};
 
+    private static final Map<String, FastImageEnterTransition> FAST_IMAGE_ENTER_TRANSITION_MAP =
+            new HashMap<String, FastImageEnterTransition>() {{
+                put("none", FastImageEnterTransition.TRANSITION_NONE);
+                put("curlDown", FastImageEnterTransition.TRANSITION_NONE);
+                put("curlUp", FastImageEnterTransition.TRANSITION_NONE);
+                put("fadeIn", FastImageEnterTransition.FADE_IN);
+                put("flipBottom", FastImageEnterTransition.FLIP_BOTTOM);
+                put("flipLeft", FastImageEnterTransition.FLIP_LEFT);
+                put("flipRight", FastImageEnterTransition.FLIP_RIGHT);
+                put("flipTop", FastImageEnterTransition.FLIP_TOP);
+            }};
+
     // Resolve the source uri to a file path that android understands.
     static @Nullable
     FastImageSource getImageSource(Context context, @Nullable ReadableMap source) {
@@ -123,6 +135,10 @@ class FastImageViewConverter {
 
     private static FastImageCacheControl getCacheControl(ReadableMap source) {
         return getValueFromSource("cache", "immutable", FAST_IMAGE_CACHE_CONTROL_MAP, source);
+    }
+
+    static FastImageEnterTransition getEnterTransition(String propValue) {
+        return getValue("enterTransition", "none", FAST_IMAGE_ENTER_TRANSITION_MAP, propValue);
     }
 
     private static Priority getPriority(ReadableMap source) {

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
@@ -83,6 +83,17 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
         view.setScaleType(scaleType);
     }
 
+    @ReactProp(name = "enterTransition")
+    public void setEnterTransition(FastImageViewWithUrl view, String enterTransition) {
+        final FastImageEnterTransition transition = FastImageViewConverter.getEnterTransition(enterTransition);
+        view.setEnterTransition(transition);
+    }
+
+    @ReactProp(name = "transitionDuration")
+    public void setTransitionDuration(FastImageViewWithUrl view, int transitionDuration) {
+        view.setTransitionDuration(transitionDuration);
+    }
+
     @Override
     public void onDropViewInstance(@NonNull FastImageViewWithUrl view) {
         // This will cancel existing requests.

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewWithUrl.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewWithUrl.java
@@ -30,6 +30,8 @@ class FastImageViewWithUrl extends AppCompatImageView {
     private boolean mNeedsReload = false;
     private ReadableMap mSource = null;
     private Drawable mDefaultSource = null;
+    private FastImageEnterTransition mEnterTransition = FastImageEnterTransition.TRANSITION_NONE;
+    private int mTransitionDuration = 500;
 
     public GlideUrl glideUrl;
 
@@ -45,6 +47,14 @@ class FastImageViewWithUrl extends AppCompatImageView {
     public void setDefaultSource(@Nullable Drawable source) {
         mNeedsReload = true;
         mDefaultSource = source;
+    }
+
+    public void setEnterTransition(@Nullable FastImageEnterTransition transition) {
+        mEnterTransition = transition;
+    }
+
+    public void setTransitionDuration(int duration) {
+        mTransitionDuration = duration == 0 ? 500 : duration;
     }
 
     private boolean isNullOrEmpty(final String url) {
@@ -146,6 +156,10 @@ class FastImageViewWithUrl extends AppCompatImageView {
 
             if (key != null)
                 builder.listener(new FastImageRequestListener(key));
+
+            if (mEnterTransition != FastImageEnterTransition.TRANSITION_NONE) {
+                builder.transition(FastImageTransitions.getEnterTransition(mEnterTransition, mTransitionDuration));
+            }
 
             builder.into(this);
         }

--- a/ios/FastImage/FFFastImageView.h
+++ b/ios/FastImage/FFFastImageView.h
@@ -7,6 +7,7 @@
 #import <React/RCTResizeMode.h>
 
 #import "FFFastImageSource.h"
+#import "FFFastImageViewManager.h"
 
 @interface FFFastImageView : SDAnimatedImageView
 
@@ -16,6 +17,8 @@
 @property (nonatomic, copy) RCTDirectEventBlock onFastImageLoad;
 @property (nonatomic, copy) RCTDirectEventBlock onFastImageLoadEnd;
 @property (nonatomic, assign) RCTResizeMode resizeMode;
+@property (nonatomic, assign) FFFEnterTransition enterTransition;
+@property (nonatomic, assign) NSTimeInterval transitionDuration;
 @property (nonatomic, strong) FFFastImageSource *source;
 @property (nonatomic, strong) UIImage *defaultSource;
 @property (nonatomic, strong) UIColor *imageColor;

--- a/ios/FastImage/FFFastImageView.m
+++ b/ios/FastImage/FFFastImageView.m
@@ -71,6 +71,42 @@
     }
 }
 
+- (void) setTransitionDuration: (NSTimeInterval)transitionDuration {
+   self.sd_imageTransition.duration = transitionDuration;
+}
+
+- (void) setEnterTransition: (FFFEnterTransition)enterTransition {
+    switch (enterTransition) {
+        case FFFFadeIn:
+            self.sd_imageTransition = SDWebImageTransition.fadeTransition;
+            break;
+            
+        case FFFCurlUp:
+            self.sd_imageTransition = SDWebImageTransition.curlUpTransition;
+            break;
+        
+        case FFFCurlDown:
+            self.sd_imageTransition = SDWebImageTransition.curlDownTransition;
+            break;
+            
+        case FFFFlipBottom:
+            self.sd_imageTransition = SDWebImageTransition.flipFromBottomTransition;
+            break;
+            
+        case FFFFlipLeft:
+            self.sd_imageTransition = SDWebImageTransition.flipFromLeftTransition;
+            break;
+            
+        case FFFFlipRight:
+            self.sd_imageTransition = SDWebImageTransition.flipFromRightTransition;
+            break;
+            
+        case FFFFlipTop:
+            self.sd_imageTransition = SDWebImageTransition.flipFromTopTransition;
+            break;
+    }
+}
+
 - (UIImage*) makeImage: (UIImage*)image withTint: (UIColor*)color {
     UIImage* newImage = [image imageWithRenderingMode: UIImageRenderingModeAlwaysTemplate];
     UIGraphicsBeginImageContextWithOptions(image.size, NO, newImage.scale);

--- a/ios/FastImage/FFFastImageViewManager.h
+++ b/ios/FastImage/FFFastImageViewManager.h
@@ -1,5 +1,16 @@
 #import <React/RCTViewManager.h>
 
+typedef NS_ENUM(NSInteger, FFFEnterTransition) {
+    FFFTransitionNone,
+    FFFFadeIn,
+    FFFCurlDown,
+    FFFCurlUp,
+    FFFFlipBottom,
+    FFFFlipLeft,
+    FFFFlipRight,
+    FFFFlipTop,
+};
+
 @interface FFFastImageViewManager : RCTViewManager
 
 @end

--- a/ios/FastImage/FFFastImageViewManager.m
+++ b/ios/FastImage/FFFastImageViewManager.m
@@ -13,6 +13,8 @@ RCT_EXPORT_MODULE(FastImageView)
 }
 
 RCT_EXPORT_VIEW_PROPERTY(source, FFFastImageSource)
+RCT_EXPORT_VIEW_PROPERTY(enterTransition, FFFEnterTransition)
+RCT_EXPORT_VIEW_PROPERTY(transitionDuration, NSTimeInterval)
 RCT_EXPORT_VIEW_PROPERTY(defaultSource, UIImage)
 RCT_EXPORT_VIEW_PROPERTY(resizeMode, RCTResizeMode)
 RCT_EXPORT_VIEW_PROPERTY(onFastImageLoadStart, RCTDirectEventBlock)

--- a/ios/FastImage/RCTConvert+FFFastImage.m
+++ b/ios/FastImage/RCTConvert+FFFastImage.m
@@ -1,5 +1,6 @@
 #import "RCTConvert+FFFastImage.h"
 #import "FFFastImageSource.h"
+#import "FFFastImageViewManager.h"
 
 @implementation RCTConvert (FFFastImage)
 
@@ -14,6 +15,17 @@ RCT_ENUM_CONVERTER(FFFCacheControl, (@{
                                        @"web": @(FFFCacheControlWeb),
                                        @"cacheOnly": @(FFFCacheControlCacheOnly),
                                        }), FFFCacheControlImmutable, integerValue);
+
+RCT_ENUM_CONVERTER(FFFEnterTransition, (@{
+                                          @"none": @(FFFTransitionNone),
+                                          @"fadeIn": @(FFFFadeIn),
+                                          @"curlDown": @(FFFCurlDown),
+                                          @"curlUp": @(FFFCurlUp),
+                                          @"flipBottom": @(FFFFlipBottom),
+                                          @"flipLeft": @(FFFFlipLeft),
+                                          @"flipRight": @(FFFFlipRight),
+                                          @"flipTop": @(FFFFlipTop), 
+                                          }), FFFTransitionNone, integerValue);
 
 + (FFFastImageSource *)FFFastImageSource:(id)json {
     if (!json) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,6 +17,29 @@ import {
     ColorValue,
 } from 'react-native'
 
+export type EnterTransition =
+    | 'fadeIn'
+    | 'curlDown'
+    | 'curlUp'
+    | 'flipBottom'
+    | 'flipLeft'
+    | 'flipRight'
+    | 'flipTop'
+    | 'none'
+
+const enterTransition = {
+    fadeIn: 'fadeIn',
+    /** iOS only */
+    curlDown: 'curlDown',
+    /** iOS only */
+    curlUp: 'curlUp',
+    flipBottom: 'flipBottom',
+    flipLeft: 'flipLeft',
+    flipRight: 'flipRight',
+    flipTop: 'flipTop',
+    none: 'none',
+} as const
+
 export type ResizeMode = 'contain' | 'cover' | 'stretch' | 'center'
 
 const resizeMode = {
@@ -85,6 +108,18 @@ export interface FastImageProps extends AccessibilityProps, ViewProps {
     defaultSource?: ImageRequireSource
     resizeMode?: ResizeMode
     fallback?: boolean
+
+    /**
+     * Transition durations.
+     * @default none
+     */
+    enterTransition?: EnterTransition
+
+    /**
+     * Enter transition duration in ms.
+     * @default 500ms
+     */
+    transitionDuration?: number
 
     onLoadStart?(): void
 
@@ -228,6 +263,7 @@ const FastImageComponent: React.ComponentType<FastImageProps> = forwardRef(
 FastImageComponent.displayName = 'FastImage'
 
 export interface FastImageStaticProperties {
+    enterTransition: typeof enterTransition
     resizeMode: typeof resizeMode
     priority: typeof priority
     cacheControl: typeof cacheControl
@@ -244,6 +280,8 @@ FastImage.resizeMode = resizeMode
 FastImage.cacheControl = cacheControl
 
 FastImage.priority = priority
+
+FastImage.enterTransition = enterTransition
 
 FastImage.preload = (sources: Source[]) =>
     NativeModules.FastImageView.preload(sources)


### PR DESCRIPTION
Hey @DylanVann

This PR provide several image transitions.
On iOS used [default](https://sdwebimage.github.io/documentation/sdwebimage/sdwebimagetransition/?language=objc) SDWebImage transitions.
On Android used [default](https://bumptech.github.io/glide/javadocs/400/com/bumptech/glide/load/resource/drawable/DrawableTransitionOptions.html) glide crossFade transition. Other transitions are implemented through the [ObjectAnimator](https://developer.android.com/reference/android/animation/ObjectAnimator).

Some of the code has been provided in https://github.com/DylanVann/react-native-fast-image/pull/876 👏