### PR TITLE
Upgrade SDWebImage to 5.15.1 to solve IOS App crash with SDAnimatedImage initWithData error

### DIFF
--- a/RNFastImage.podspec
+++ b/RNFastImage.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/**/*.{h,m}"
 
   s.dependency 'React-Core'
-  s.dependency 'SDWebImage', '~> 5.11.1'
-  s.dependency 'SDWebImageWebPCoder', '~> 0.8.4'
+  s.dependency 'SDWebImage', '~> 5.15.1'
+  s.dependency 'SDWebImageWebPCoder', '~> 0.9.1'
 end


### PR DESCRIPTION
This updates the version of SDWebImage to 5.15.1 , which has fixes for crash due to SDAnimatedImage initWithData error observed in RN 0.68.1 for IOS Application due to OOM issue. This fixes  #[3480](https://github.com/SDWebImage/SDWebImage/pull/3480)  https://github.com/SDWebImage/SDWebImage/issues/3303
