### PR TITLE
Explain that the library does not work in Expo Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ and
 -   [x] GIF support.
 -   [x] Border radius.
 
+## Expo
+
+- ✅ You can use this library with [Development Builds](https://docs.expo.dev/development/introduction/). No config plugin is required.
+- ❌ This library can't be used in the "Expo Go" app because it [requires custom native code](https://docs.expo.dev/workflow/customizing/).
+
 ## Usage
 
 **Note: You must be using React Native 0.60.0 or higher to use the most recent version of `react-native-fast-image`.**


### PR DESCRIPTION
This will help with issues like https://github.com/DylanVann/react-native-fast-image/issues/969

This is the same convention that is documented on https://expo.notion.site/Documenting-Expo-support-in-READMEs-f250a20b4bd5472cab0757918cb21062 and used in libraries like [react-native-blurhash](https://github.com/mrousavy/react-native-blurhash#expo)