### PR TITLE
feat: Extend Disable Transformation property for Android

### DIFF
--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
@@ -61,6 +61,11 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
         view.setSource(source);
     }
 
+    @ReactProp(name = "disableTransformation")
+    public void setDisableTransformation(FastImageViewWithUrl view, @Nullable Boolean disableTransformation) {
+        view.disableTransformation(disableTransformation);
+    }
+
     @ReactProp(name = "defaultSource")
     public void setDefaultSource(FastImageViewWithUrl view, @Nullable String source) {
         view.setDefaultSource(

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewWithUrl.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewWithUrl.java
@@ -30,6 +30,7 @@ class FastImageViewWithUrl extends AppCompatImageView {
     private boolean mNeedsReload = false;
     private ReadableMap mSource = null;
     private Drawable mDefaultSource = null;
+    private boolean mDisableTransformation = false;
 
     public GlideUrl glideUrl;
 
@@ -40,6 +41,11 @@ class FastImageViewWithUrl extends AppCompatImageView {
     public void setSource(@Nullable ReadableMap source) {
         mNeedsReload = true;
         mSource = source;
+    }
+
+    public void disableTransformation(@Nullable boolean disableTransform) {
+        mNeedsReload = true;
+        mDisableTransformation = disableTransform;
     }
 
     public void setDefaultSource(@Nullable Drawable source) {
@@ -143,6 +149,10 @@ class FastImageViewWithUrl extends AppCompatImageView {
                                     .getOptions(context, imageSource, mSource)
                                     .placeholder(mDefaultSource) // show until loaded
                                     .fallback(mDefaultSource)); // null will not be treated as error
+
+            if (mDisableTransformation) {
+                builder = builder.dontTransform();
+            }
 
             if (key != null)
                 builder.listener(new FastImageRequestListener(key));

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -116,8 +116,14 @@ export interface FastImageProps extends AccessibilityProps, ViewProps {
      *
      * If supplied, changes the color of all the non-transparent pixels to the given color.
      */
-
     tintColor?: ColorValue
+
+    /**
+     * If supplied, the original size of the resource without any transformations will be displayed.
+     * 
+     * @platform android
+     */
+    disableTransformation?: boolean
 
     /**
      * A unique identifier for this element to be used in UI Automation testing scripts.


### PR DESCRIPTION
## Details:

This Pull Request introduces the new property `disableTransformation` for an android platform that disables transform in the glide framework and keeps the original size of the resource.

Related issue: https://github.com/Expensify/App/issues/12893