### PR TITLE
Add export to Cache type

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -34,7 +34,7 @@ const priority = {
     high: 'high',
 } as const
 
-type Cache = 'immutable' | 'web' | 'cacheOnly'
+export type Cache = 'immutable' | 'web' | 'cacheOnly'
 
 const cacheControl = {
     // Ignore headers, use uri as cache key, fetch only if not in cache.


### PR DESCRIPTION
In accordance with all `react-native-fast-image` types just add export to the `Cache` type