### PR TITLE
Fixed graphics context allocation issue

### DIFF
--- a/ios/FastImage/FFFastImageView.m
+++ b/ios/FastImage/FFFastImageView.m
@@ -71,13 +71,13 @@
     }
 }
 
-- (UIImage*) makeImage: (UIImage*)image withTint: (UIColor*)color {
-    UIImage* newImage = [image imageWithRenderingMode: UIImageRenderingModeAlwaysTemplate];
-    UIGraphicsBeginImageContextWithOptions(image.size, NO, newImage.scale);
-    [color set];
-    [newImage drawInRect: CGRectMake(0, 0, image.size.width, newImage.size.height)];
-    newImage = UIGraphicsGetImageFromCurrentImageContext();
-    UIGraphicsEndImageContext();
+- (UIImage*)makeImage:(UIImage *)image withTint:(UIColor *)color {
+    UIImage *newImage = [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:image.size];
+    newImage = [renderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull rendererContext) {
+        [color setFill];
+        [newImage drawInRect:CGRectMake(0, 0, image.size.width, newImage.size.height)];
+    }];
     return newImage;
 }
 


### PR DESCRIPTION
**Title: Resolved Graphics Context Allocation Issue**

**Description:**

**Proposed Changes**
This PR resolves an issue pertaining to graphics context allocation in the FFFastImageViewManager. The previous implementation utilized older graphics context handling methods, which could potentially lead to errors. This PR updates the code to leverage the newer UIGraphicsImageRenderer API, mitigating any context allocation problems.

**Changes Made**
- Updated FFFastImageViewManager.m to utilize UIGraphicsImageRenderer for managing image context.
- Eliminated manual handling of context creation and cleanup, reducing the likelihood of errors.

**Graphics Context Handling:**
It now employs UIGraphicsImageRenderer, a more modern API introduced in iOS 10. This API handles the creation, rendering, and cleanup of the image context automatically.

**Renderer Usage:**
It now creates a UIGraphicsImageRenderer object (renderer) and employs it to execute the drawing operations.

**Error Handling:**
It leverages a more modern API that is less susceptible to context allocation errors.

This PR addresses: #1006