### PR TITLE
Handle undefined callbacks in setters on iOS native module

### DIFF
--- a/ios/FastImage/FFFastImageView.m
+++ b/ios/FastImage/FFFastImageView.m
@@ -32,21 +32,21 @@
 
 - (void) setOnFastImageLoadEnd: (RCTDirectEventBlock)onFastImageLoadEnd {
     _onFastImageLoadEnd = onFastImageLoadEnd;
-    if (self.hasCompleted) {
+    if (self.hasCompleted && _onFastImageLoadEnd) {
         _onFastImageLoadEnd(@{});
     }
 }
 
 - (void) setOnFastImageLoad: (RCTDirectEventBlock)onFastImageLoad {
     _onFastImageLoad = onFastImageLoad;
-    if (self.hasCompleted) {
+    if (self.hasCompleted && _onFastImageLoad) {
         _onFastImageLoad(self.onLoadEvent);
     }
 }
 
 - (void) setOnFastImageError: (RCTDirectEventBlock)onFastImageError {
     _onFastImageError = onFastImageError;
-    if (self.hasErrored) {
+    if (self.hasErrored && _onFastImageError) {
         _onFastImageError(@{});
     }
 }
@@ -54,7 +54,9 @@
 - (void) setOnFastImageLoadStart: (RCTDirectEventBlock)onFastImageLoadStart {
     if (_source && !self.hasSentOnLoadStart) {
         _onFastImageLoadStart = onFastImageLoadStart;
-        onFastImageLoadStart(@{});
+        if (onFastImageLoadStart) {
++            onFastImageLoadStart(@{});
++        }
         self.hasSentOnLoadStart = YES;
     } else {
         _onFastImageLoadStart = onFastImageLoadStart;


### PR DESCRIPTION
Sequence of events that ends up with crash are:

1. Set one of the callback with a function (ie. onError)
2. Try to load an invalid image, that will result with onError callback being called.
3. Set onError callback to `undefined`.

At this point, native iOS module tries to call the `undefined` function, which crashes the app with `EXT_BAD_ACCESS`.

This PR updates all setter functions and checks if the callback function exists before calling them.