### PR TITLE
Aa/STR-1985 fix huge size issue when releasing

### DIFF
--- a/RNFastImage.podspec
+++ b/RNFastImage.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/**/*.{h,m}"
 
   s.dependency 'React-Core'
-  s.dependency 'SDWebImage', '~> 5.11.1'
+  s.dependency 'SDWebImage', '~> 5.18.1'
   s.dependency 'SDWebImageWebPCoder', '~> 0.8.4'
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -64,5 +64,6 @@ dependencies {
     implementation 'com.facebook.react:react-native:+'  // From node_modules
     implementation "com.github.bumptech.glide:glide:${glideVersion}"
     implementation "com.github.bumptech.glide:okhttp3-integration:${glideVersion}"
+    implementation "com.github.zjupure:webpdecoder:2.0.${glideVersion}"
     annotationProcessor "com.github.bumptech.glide:compiler:${glideVersion}"
 }

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageRequestListener.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageRequestListener.java
@@ -2,6 +2,7 @@ package com.dylanvann.fastimage;
 
 import android.graphics.drawable.Drawable;
 
+import com.bumptech.glide.integration.webp.decoder.WebpDrawable;
 import com.bumptech.glide.load.DataSource;
 import com.bumptech.glide.load.engine.GlideException;
 import com.bumptech.glide.request.RequestListener;
@@ -24,9 +25,11 @@ public class FastImageRequestListener implements RequestListener<Drawable> {
     }
 
     private static WritableMap mapFromResource(Drawable resource) {
+        boolean isAnimated = (resource instanceof WebpDrawable) && ((WebpDrawable) resource).getFrameCount() > 1;
         WritableMap resourceData = new WritableNativeMap();
         resourceData.putInt("width", resource.getIntrinsicWidth());
         resourceData.putInt("height", resource.getIntrinsicHeight());
+        resourceData.putBoolean("isAnimated", isAnimated);
         return resourceData;
     }
 

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewConverter.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewConverter.java
@@ -4,15 +4,11 @@ import android.content.Context;
 import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
-import android.media.Image;
-import android.net.Uri;
-import android.util.Log;
 import android.widget.ImageView;
 import android.widget.ImageView.ScaleType;
 
 import com.bumptech.glide.Priority;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
-import com.bumptech.glide.load.model.GlideUrl;
 import com.bumptech.glide.load.model.Headers;
 import com.bumptech.glide.load.model.LazyHeaders;
 import com.bumptech.glide.request.RequestOptions;
@@ -21,15 +17,9 @@ import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.NoSuchKeyException;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableMapKeySetIterator;
-import com.facebook.react.views.imagehelper.ImageSource;
-
-import java.io.File;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.annotation.Nullable;
 
 import static com.bumptech.glide.request.RequestOptions.signatureOf;
 

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewConverter.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewConverter.java
@@ -74,7 +74,7 @@ class FastImageViewConverter {
         return headers;
     }
 
-    static RequestOptions getOptions(Context context, FastImageSource imageSource, ReadableMap source) {
+    static RequestOptions getOptions(Context context, FastImageSource imageSource, ReadableMap source, Drawable placeholderDrawable) {
         // Get priority.
         final Priority priority = FastImageViewConverter.getPriority(source);
         // Get cache control method.
@@ -101,7 +101,7 @@ class FastImageViewConverter {
             .onlyRetrieveFromCache(onlyFromCache)
             .skipMemoryCache(skipMemoryCache)
             .priority(priority)
-            .placeholder(TRANSPARENT_DRAWABLE);
+            .placeholder(placeholderDrawable != null ? placeholderDrawable : TRANSPARENT_DRAWABLE);
         
         if (imageSource.isResource()) {
             // Every local resource (drawable) in Android has its own unique numeric id, which are

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
@@ -4,12 +4,16 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.ContextWrapper;
 import android.graphics.PorterDuff;
+import android.graphics.drawable.Drawable;
 import android.os.Build;
 
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.RequestManager;
+import com.bumptech.glide.integration.webp.decoder.WebpDrawable;
 import com.bumptech.glide.load.model.GlideUrl;
 import com.bumptech.glide.request.Request;
+import com.bumptech.glide.request.target.DrawableImageViewTarget;
+import com.bumptech.glide.request.transition.Transition;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeMap;
@@ -30,6 +34,8 @@ import javax.annotation.Nullable;
 import static com.dylanvann.fastimage.FastImageRequestListener.REACT_ON_ERROR_EVENT;
 import static com.dylanvann.fastimage.FastImageRequestListener.REACT_ON_LOAD_END_EVENT;
 import static com.dylanvann.fastimage.FastImageRequestListener.REACT_ON_LOAD_EVENT;
+
+import androidx.annotation.NonNull;
 
 class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> implements FastImageProgressListener {
 
@@ -124,7 +130,17 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
                     .load(imageSource.getSourceForLoad())
                     .apply(FastImageViewConverter.getOptions(context, imageSource, source))
                     .listener(new FastImageRequestListener(key))
-                    .into(view);
+                    .into(new DrawableImageViewTarget(view) {
+                        @Override
+                        public void onResourceReady(@NonNull Drawable resource, @Nullable Transition<? super Drawable> transition) {
+                            super.onResourceReady(resource, transition);
+                            if (resource instanceof WebpDrawable) {
+                                WebpDrawable webpDrawable = (WebpDrawable) resource;
+                                webpDrawable.setLoopCount(1);
+                                webpDrawable.stop();
+                            }
+                        }
+                    });
         }
     }
 

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
@@ -22,6 +22,7 @@ import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
+import com.facebook.react.views.imagehelper.ResourceDrawableIdHelper;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -119,6 +120,8 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
         int viewId = view.getId();
         eventEmitter.receiveEvent(viewId, REACT_ON_LOAD_START_EVENT, new WritableNativeMap());
 
+        Drawable placeholderDrawable = view.getPlaceholderDrawable();
+
         if (requestManager != null) {
             requestManager
                     // This will make this work for remote and local images. e.g.
@@ -128,7 +131,7 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
                     //    - android.resource://
                     //    - data:image/png;base64
                     .load(imageSource.getSourceForLoad())
-                    .apply(FastImageViewConverter.getOptions(context, imageSource, source))
+                    .apply(FastImageViewConverter.getOptions(context, imageSource, source, placeholderDrawable))
                     .listener(new FastImageRequestListener(key))
                     .into(new DrawableImageViewTarget(view) {
                         @Override
@@ -142,6 +145,12 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
                         }
                     });
         }
+    }
+
+    @ReactProp(name = "defaultSource")
+    public void setDefaultSource(FastImageViewWithUrl view, @Nullable String source) {
+        Drawable drawable = ResourceDrawableIdHelper.getInstance().getResourceDrawable(view.getContext(), source);
+        view.setPlaceholderDrawable(drawable);
     }
 
     @ReactProp(name = "tintColor", customType = "Color")

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewModule.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewModule.java
@@ -3,14 +3,13 @@ package com.dylanvann.fastimage;
 import android.app.Activity;
 
 import com.bumptech.glide.Glide;
-import com.bumptech.glide.load.model.GlideUrl;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
-import com.facebook.react.views.imagehelper.ImageSource;
+import com.facebook.react.uimanager.UIManagerModule;
 
 class FastImageViewModule extends ReactContextBaseJavaModule {
 
@@ -23,6 +22,19 @@ class FastImageViewModule extends ReactContextBaseJavaModule {
     @Override
     public String getName() {
         return REACT_CLASS;
+    }
+
+    @ReactMethod
+    public void playAnimation(final int reactTag) {
+        final ReactApplicationContext context = getReactApplicationContext();
+        UIManagerModule uiManager = context.getNativeModule(UIManagerModule.class);
+        uiManager.addUIBlock(nvhm -> {
+            FastImageViewWithUrl view = (FastImageViewWithUrl) nvhm.resolveView(reactTag);
+            if (view == null) {
+                return;
+            }
+            view.playAnimation();
+        });
     }
 
     @ReactMethod

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewModule.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewModule.java
@@ -60,7 +60,7 @@ class FastImageViewModule extends ReactContextBaseJavaModule {
                                     imageSource.isBase64Resource() ? imageSource.getSource() :
                                     imageSource.isResource() ? imageSource.getUri() : imageSource.getGlideUrl()
                             )
-                            .apply(FastImageViewConverter.getOptions(activity, imageSource, source))
+                            .apply(FastImageViewConverter.getOptions(activity, imageSource, source, null))
                             .preload();
                 }
             }

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewWithUrl.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewWithUrl.java
@@ -1,13 +1,23 @@
 package com.dylanvann.fastimage;
 
 import android.content.Context;
-
 import androidx.appcompat.widget.AppCompatImageView;
 
+import com.bumptech.glide.integration.webp.decoder.WebpDrawable;
 import com.bumptech.glide.load.model.GlideUrl;
 
 class FastImageViewWithUrl extends AppCompatImageView {
     public GlideUrl glideUrl;
+
+    public void playAnimation() {
+        if (this.getDrawable() instanceof WebpDrawable) {
+            WebpDrawable drawable = (WebpDrawable) this.getDrawable();
+            if (!drawable.isRunning()) {
+                drawable.stop();
+                drawable.startFromFirstFrame();
+            }
+        }
+    }
 
     public FastImageViewWithUrl(Context context) {
         super(context);

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewWithUrl.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewWithUrl.java
@@ -1,6 +1,7 @@
 package com.dylanvann.fastimage;
 
 import android.content.Context;
+import android.graphics.drawable.Drawable;
 import androidx.appcompat.widget.AppCompatImageView;
 
 import com.bumptech.glide.integration.webp.decoder.WebpDrawable;
@@ -8,6 +9,7 @@ import com.bumptech.glide.load.model.GlideUrl;
 
 class FastImageViewWithUrl extends AppCompatImageView {
     public GlideUrl glideUrl;
+    private Drawable placeholderDrawable;
 
     public void playAnimation() {
         if (this.getDrawable() instanceof WebpDrawable) {
@@ -17,6 +19,14 @@ class FastImageViewWithUrl extends AppCompatImageView {
                 drawable.startFromFirstFrame();
             }
         }
+    }
+
+    public Drawable getPlaceholderDrawable() {
+        return placeholderDrawable;
+    }
+
+    public void setPlaceholderDrawable(Drawable placeholderDrawable) {
+        this.placeholderDrawable = placeholderDrawable;
     }
 
     public FastImageViewWithUrl(Context context) {

--- a/ios/FastImage/FFFastImageView.h
+++ b/ios/FastImage/FFFastImageView.h
@@ -19,5 +19,7 @@
 @property (nonatomic, strong) FFFastImageSource *source;
 @property (nonatomic, strong) UIColor *imageColor;
 
+- (void)playAnimation;
+
 @end
 

--- a/ios/FastImage/FFFastImageView.h
+++ b/ios/FastImage/FFFastImageView.h
@@ -18,6 +18,7 @@
 @property (nonatomic, assign) RCTResizeMode resizeMode;
 @property (nonatomic, strong) FFFastImageSource *source;
 @property (nonatomic, strong) UIColor *imageColor;
+@property (nonatomic, strong) UIImage *placeholderImage;
 
 - (void)playAnimation;
 

--- a/ios/FastImage/FFFastImageView.m
+++ b/ios/FastImage/FFFastImageView.m
@@ -211,7 +211,7 @@
     __weak typeof(self) weakSelf = self; // Always use a weak reference to self in blocks
     
     [self sd_setImageWithURL:_source.url
-            placeholderImage:nil
+            placeholderImage:_placeholderImage
                      options:options
                      context:context
                     progress:^(NSInteger receivedSize, NSInteger expectedSize, NSURL * _Nullable targetURL) {

--- a/ios/FastImage/FFFastImageViewManager.m
+++ b/ios/FastImage/FFFastImageViewManager.m
@@ -1,6 +1,9 @@
 #import "FFFastImageViewManager.h"
 #import "FFFastImageView.h"
 
+#import <React/RCTUIManager.h>
+#import <React/RCTViewManager.h>
+
 #import <SDWebImage/SDImageCache.h>
 #import <SDWebImage/SDWebImagePrefetcher.h>
 
@@ -20,6 +23,18 @@ RCT_EXPORT_VIEW_PROPERTY(onFastImageError, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onFastImageLoad, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onFastImageLoadEnd, RCTDirectEventBlock)
 RCT_REMAP_VIEW_PROPERTY(tintColor, imageColor, UIColor)
+
+RCT_EXPORT_METHOD(playAnimation : (nonnull NSNumber *)reactTag)
+{
+    [self.bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *,UIView *> *viewRegistry) {
+        UIView *view = viewRegistry[reactTag];
+        if (!view || ![view isKindOfClass:[FFFastImageView class]]) {
+          RCTLogError(@"Cannot find NativeView with tag #%@", reactTag);
+          return;
+        }
+        [(FFFastImageView *)view playAnimation];
+    }];
+}
 
 RCT_EXPORT_METHOD(preload:(nonnull NSArray<FFFastImageSource *> *)sources)
 {

--- a/ios/FastImage/FFFastImageViewManager.m
+++ b/ios/FastImage/FFFastImageViewManager.m
@@ -23,6 +23,7 @@ RCT_EXPORT_VIEW_PROPERTY(onFastImageError, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onFastImageLoad, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onFastImageLoadEnd, RCTDirectEventBlock)
 RCT_REMAP_VIEW_PROPERTY(tintColor, imageColor, UIColor)
+RCT_REMAP_VIEW_PROPERTY(defaultSource, placeholderImage, UIImage)
 
 RCT_EXPORT_METHOD(playAnimation : (nonnull NSNumber *)reactTag)
 {

--- a/package.json
+++ b/package.json
@@ -24,9 +24,7 @@
     "typings": "dist/index.d.ts",
     "files": [
         "android",
-        "!android/build",
         "ios",
-        "!ios/build",
         "dist",
         "RNFastImage.podspec"
     ],

--- a/package.json
+++ b/package.json
@@ -78,8 +78,5 @@
     "peerDependencies": {
         "react": "^16.8.6 || ^17.0.0",
         "react-native": ">=0.60.0"
-    },
-    "publishConfig": {
-        "registry": "https://nexus.global.picnicinternational.com/repository/npm-releases/"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-fast-image",
-    "version": "8.5.11",
+    "version": "8.5.11-picnic.10",
     "description": "🚩 FastImage, performant React Native image component.",
     "keywords": [
         "cache",
@@ -78,5 +78,8 @@
     "peerDependencies": {
         "react": "^16.8.6 || ^17.0.0",
         "react-native": ">=0.60.0"
+    },
+    "publishConfig": {
+        "registry": "https://nexus.global.picnicinternational.com/repository/npm-releases/"
     }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,17 +11,16 @@ import {
     NativeModules,
     requireNativeComponent,
     StyleSheet,
-    FlexStyle,
     LayoutChangeEvent,
-    ShadowStyleIOS,
     StyleProp,
-    TransformsStyle,
     AccessibilityProps,
     ViewProps,
     NativeMethods,
     Platform,
     ImageRequireSource,
     findNodeHandle,
+    ImageStyle,
+    ColorValue,
 } from 'react-native'
 
 const FastImageViewNativeModule = NativeModules.FastImageView
@@ -76,21 +75,6 @@ export interface OnProgressEvent {
     }
 }
 
-export interface ImageStyle extends FlexStyle, TransformsStyle, ShadowStyleIOS {
-    backfaceVisibility?: 'visible' | 'hidden'
-    borderBottomLeftRadius?: number
-    borderBottomRightRadius?: number
-    backgroundColor?: string
-    borderColor?: string
-    borderWidth?: number
-    borderRadius?: number
-    borderTopLeftRadius?: number
-    borderTopRightRadius?: number
-    overlayColor?: string
-    tintColor?: string
-    opacity?: number
-}
-
 export interface FastImageProps extends AccessibilityProps, ViewProps {
     source: Source | ImageRequireSource
     defaultSource?: ImageRequireSource
@@ -128,7 +112,7 @@ export interface FastImageProps extends AccessibilityProps, ViewProps {
      * If supplied, changes the color of all the non-transparent pixels to the given color.
      */
 
-    tintColor?: number | string
+    tintColor?: ColorValue
 
     /**
      * A unique identifier for this element to be used in UI Automation testing scripts.
@@ -230,9 +214,9 @@ function FastImageBase({
 const FastImageMemo = memo(FastImageBase)
 
 const FastImageComponent: React.ComponentType<FastImageProps> = forwardRef(
-    (props: FastImageProps, ref: React.Ref<any>) => (
-        <FastImageMemo forwardedRef={ref} {...props} />
-    ),
+    (props: FastImageProps, ref: React.Ref<any>) => {
+        return <FastImageMemo forwardedRef={ref} {...props} />
+    },
 )
 
 FastImageComponent.displayName = 'FastImage'

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -160,17 +160,13 @@ function FastImageBase({
         },
     }))
 
-    if (fallback) {
-        const cleanedSource = { ...(source as any) }
-        delete cleanedSource.cache
-        const resolvedSource = Image.resolveAssetSource(cleanedSource)
-
+    if (fallback || Platform.OS === 'web') {
         return (
             <View style={[styles.imageContainer, style]} ref={outerRef}>
                 <Image
                     {...props}
                     style={StyleSheet.absoluteFill}
-                    source={resolvedSource}
+                    source={source as any}
                     onLoadStart={onLoadStart}
                     onProgress={onProgress}
                     onLoad={onLoad as any}
@@ -246,11 +242,13 @@ FastImage.cacheControl = cacheControl
 FastImage.priority = priority
 
 FastImage.preload = (sources: Source[]) =>
-    FastImageViewNativeModule.preload(sources)
+    Platform.OS !== 'web' && FastImageViewNativeModule.preload(sources)
 
-FastImage.clearMemoryCache = () => FastImageViewNativeModule.clearMemoryCache()
+FastImage.clearMemoryCache = () =>
+    Platform.OS !== 'web' && FastImageViewNativeModule.clearMemoryCache()
 
-FastImage.clearDiskCache = () => FastImageViewNativeModule.clearDiskCache()
+FastImage.clearDiskCache = () =>
+    Platform.OS !== 'web' && FastImageViewNativeModule.clearDiskCache()
 
 const styles = StyleSheet.create({
     imageContainer: {
@@ -259,18 +257,17 @@ const styles = StyleSheet.create({
 })
 
 // Types of requireNativeComponent are not correct.
-const FastImageView = (requireNativeComponent as any)(
-    'FastImageView',
-    FastImage,
-    {
-        nativeOnly: {
-            onFastImageLoadStart: true,
-            onFastImageProgress: true,
-            onFastImageLoad: true,
-            onFastImageError: true,
-            onFastImageLoadEnd: true,
-        },
-    },
-)
+const FastImageView =
+    Platform.OS === 'web'
+        ? Image
+        : (requireNativeComponent as any)('FastImageView', FastImage, {
+              nativeOnly: {
+                  onFastImageLoadStart: true,
+                  onFastImageProgress: true,
+                  onFastImageLoad: true,
+                  onFastImageError: true,
+                  onFastImageLoadEnd: true,
+              },
+          })
 
 export default FastImage

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -161,8 +161,13 @@ function FastImageBase({
     }))
 
     if (fallback || Platform.OS === 'web') {
-
-        if (source && !(typeof source === "string") && onError) onError();
+        if (
+            source &&
+            (typeof source === 'object') &&
+            source.uri === undefined &&
+            onError
+        )
+            onError()
 
         return (
             <Image

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,6 +21,7 @@ import {
     findNodeHandle,
     ImageStyle,
     ColorValue,
+    MeasureInWindowOnSuccessCallback,
 } from 'react-native'
 
 const FastImageViewNativeModule = NativeModules.FastImageView
@@ -147,8 +148,11 @@ function FastImageBase({
     ...props
 }: FastImageProps & { forwardedRef: React.Ref<any> }) {
     const innerRef = useRef<typeof FastImageView>(null)
+    const outerRef = useRef<View>(null)
 
     useImperativeHandle(forwardedRef, () => ({
+        measureInWindow: (cb: MeasureInWindowOnSuccessCallback) =>
+            outerRef.current?.measureInWindow(cb),
         playAnimation: () => {
             FastImageViewNativeModule.playAnimation(
                 findNodeHandle(innerRef?.current),
@@ -162,7 +166,7 @@ function FastImageBase({
         const resolvedSource = Image.resolveAssetSource(cleanedSource)
 
         return (
-            <View style={[styles.imageContainer, style]} ref={forwardedRef}>
+            <View style={[styles.imageContainer, style]} ref={outerRef}>
                 <Image
                     {...props}
                     style={StyleSheet.absoluteFill}
@@ -191,7 +195,7 @@ function FastImageBase({
     }
 
     return (
-        <View style={[styles.imageContainer, style]} ref={forwardedRef}>
+        <View style={[styles.imageContainer, style]} ref={outerRef}>
             <FastImageView
                 {...props}
                 ref={innerRef}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,9 +1,10 @@
-import React, { forwardRef, memo, useImperativeHandle } from 'react'
-import { RefObject } from 'react'
-import { useRef } from 'react'
-import { Platform } from 'react-native'
-import { ImageRequireSource } from 'react-native'
-import { findNodeHandle } from 'react-native'
+import React, {
+    forwardRef,
+    memo,
+    useImperativeHandle,
+    RefObject,
+    useRef,
+} from 'react'
 import {
     View,
     Image,
@@ -17,6 +18,10 @@ import {
     TransformsStyle,
     AccessibilityProps,
     ViewProps,
+    NativeMethods,
+    Platform,
+    ImageRequireSource,
+    findNodeHandle,
 } from 'react-native'
 
 const FastImageViewNativeModule = NativeModules.FastImageView
@@ -243,6 +248,7 @@ export interface FastImageStaticProperties {
 }
 
 const FastImage: React.ComponentType<FastImageProps & FastImageRefProps> &
+    NativeMethods &
     FastImageStaticProperties = FastImageComponent as any
 
 FastImage.resizeMode = resizeMode

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,7 +2,7 @@ import React, {
     forwardRef,
     memo,
     useImperativeHandle,
-    RefObject,
+    Ref,
     useRef,
 } from 'react'
 import {
@@ -142,7 +142,7 @@ export interface FastImageProps extends AccessibilityProps, ViewProps {
 }
 
 interface FastImageRefProps {
-    ref?: RefObject<typeof FastImage>
+    ref?: Ref<typeof FastImage>
 }
 
 function FastImageBase({

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -160,12 +160,16 @@ function FastImageBase({
         },
     }))
 
+    if ((tintColor === null || tintColor === undefined) && style) {
+        tintColor = StyleSheet.flatten(style).tintColor
+    }
+
     if (fallback || Platform.OS === 'web') {
         return (
             <View style={[styles.imageContainer, style]} ref={outerRef}>
                 <Image
                     {...props}
-                    style={StyleSheet.absoluteFill}
+                    style={[StyleSheet.absoluteFill, { tintColor }]}
                     source={source as any}
                     onLoadStart={onLoadStart}
                     onProgress={onProgress}
@@ -185,10 +189,6 @@ function FastImageBase({
             ? defaultSource &&
               (Image.resolveAssetSource(defaultSource)?.uri ?? null)
             : defaultSource
-
-    if ((tintColor === null || tintColor === undefined) && style) {
-        tintColor = StyleSheet.flatten(style).tintColor
-    }
 
     return (
         <View style={[styles.imageContainer, style]} ref={outerRef}>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -161,6 +161,9 @@ function FastImageBase({
     }))
 
     if (fallback || Platform.OS === 'web') {
+
+        if (source && !(typeof source === "string") && onError) onError();
+
         return (
             <Image
                 {...props}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -197,6 +197,10 @@ function FastImageBase({
               (Image.resolveAssetSource(defaultSource)?.uri ?? null)
             : defaultSource
 
+    if ((tintColor === null || tintColor === undefined) && style) {
+        tintColor = StyleSheet.flatten(style).tintColor
+    }
+
     return (
         <View style={[styles.imageContainer, style]} ref={forwardedRef}>
             <FastImageView

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,8 @@
 import React, { forwardRef, memo, useImperativeHandle } from 'react'
 import { RefObject } from 'react'
 import { useRef } from 'react'
+import { Platform } from 'react-native'
+import { ImageRequireSource } from 'react-native'
 import { findNodeHandle } from 'react-native'
 import {
     View,
@@ -85,7 +87,8 @@ export interface ImageStyle extends FlexStyle, TransformsStyle, ShadowStyleIOS {
 }
 
 export interface FastImageProps extends AccessibilityProps, ViewProps {
-    source: Source | number
+    source: Source | ImageRequireSource
+    defaultSource?: ImageRequireSource
     resizeMode?: ResizeMode
     fallback?: boolean
 
@@ -139,6 +142,7 @@ interface FastImageRefProps {
 
 function FastImageBase({
     source,
+    defaultSource,
     tintColor,
     onLoadStart,
     onProgress,
@@ -187,6 +191,11 @@ function FastImageBase({
     }
 
     const resolvedSource = Image.resolveAssetSource(source as any)
+    const resolvedDefaultSource =
+        Platform.OS === 'android'
+            ? defaultSource &&
+              (Image.resolveAssetSource(defaultSource)?.uri ?? null)
+            : defaultSource
 
     return (
         <View style={[styles.imageContainer, style]} ref={forwardedRef}>
@@ -195,6 +204,7 @@ function FastImageBase({
                 ref={innerRef}
                 tintColor={tintColor}
                 style={StyleSheet.absoluteFill}
+                defaultSource={resolvedDefaultSource}
                 source={resolvedSource}
                 onFastImageLoadStart={onLoadStart}
                 onFastImageProgress={onProgress}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -160,27 +160,25 @@ function FastImageBase({
         },
     }))
 
-    if ((tintColor === null || tintColor === undefined) && style) {
-        tintColor = StyleSheet.flatten(style).tintColor
-    }
-
     if (fallback || Platform.OS === 'web') {
         return (
-            <View style={[styles.imageContainer, style]} ref={outerRef}>
-                <Image
-                    {...props}
-                    style={[StyleSheet.absoluteFill, { tintColor }]}
-                    source={source as any}
-                    onLoadStart={onLoadStart}
-                    onProgress={onProgress}
-                    onLoad={onLoad as any}
-                    onError={onError}
-                    onLoadEnd={onLoadEnd}
-                    resizeMode={resizeMode}
-                />
-                {children}
-            </View>
+            <Image
+                {...props}
+                ref={outerRef as any}
+                style={style}
+                source={source as any}
+                onLoadStart={onLoadStart}
+                onProgress={onProgress}
+                onLoad={onLoad as any}
+                onError={onError}
+                onLoadEnd={onLoadEnd}
+                resizeMode={resizeMode}
+            />
         )
+    }
+
+    if ((tintColor === null || tintColor === undefined) && style) {
+        tintColor = StyleSheet.flatten(style).tintColor
     }
 
     const resolvedSource = Image.resolveAssetSource(source as any)


### PR DESCRIPTION
It has been noticed recently that picnic's version of react-native-fast-image package has a huge size when its released (around 50 mb). After investigation we have found that this is a yarn related issue that happens when having a negative expression in “files” entry of package.json.

This yarn issue is still open and not yet fixed, you read more about it here: https://github.com/yarnpkg/yarn/issues/8332

The fix is simply to remove the negative expressions in “files” entry of package.json, and we verified that this is a safe change.