### PR TITLE
[Android] Add support for Bridgeless Mode - 0.74

### DIFF
--- a/android/src/main/java/com/dylanvann/fastimage/FastImageRequestListener.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageRequestListener.java
@@ -7,10 +7,15 @@ import com.bumptech.glide.load.engine.GlideException;
 import com.bumptech.glide.request.RequestListener;
 import com.bumptech.glide.request.target.ImageViewTarget;
 import com.bumptech.glide.request.target.Target;
+import com.dylanvann.fastimage.events.FastImageErrorEvent;
+import com.dylanvann.fastimage.events.FastImageLoadEndEvent;
+import com.dylanvann.fastimage.events.FastImageLoadEvent;
+import com.dylanvann.fastimage.events.FastImageProgressEvent;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.uimanager.ThemedReactContext;
-import com.facebook.react.uimanager.events.RCTEventEmitter;
+import com.facebook.react.uimanager.UIManagerHelper;
+import com.facebook.react.uimanager.events.EventDispatcher;
 
 public class FastImageRequestListener implements RequestListener<Drawable> {
     static final String REACT_ON_ERROR_EVENT = "onFastImageError";
@@ -37,10 +42,15 @@ public class FastImageRequestListener implements RequestListener<Drawable> {
         }
         FastImageViewWithUrl view = (FastImageViewWithUrl) ((ImageViewTarget) target).getView();
         ThemedReactContext context = (ThemedReactContext) view.getContext();
-        RCTEventEmitter eventEmitter = context.getJSModule(RCTEventEmitter.class);
-        int viewId = view.getId();
-        eventEmitter.receiveEvent(viewId, REACT_ON_ERROR_EVENT, new WritableNativeMap());
-        eventEmitter.receiveEvent(viewId, REACT_ON_LOAD_END_EVENT, new WritableNativeMap());
+
+        EventDispatcher dispatcher = UIManagerHelper.getEventDispatcherForReactTag(context, view.getId());
+        int surfaceId = UIManagerHelper.getSurfaceId(view);
+
+        if (dispatcher != null) {
+            dispatcher.dispatchEvent(new FastImageErrorEvent(surfaceId, view.getId(), null));
+            dispatcher.dispatchEvent(new FastImageLoadEndEvent(surfaceId, view.getId()));
+        }
+
         return false;
     }
 
@@ -51,10 +61,15 @@ public class FastImageRequestListener implements RequestListener<Drawable> {
         }
         FastImageViewWithUrl view = (FastImageViewWithUrl) ((ImageViewTarget) target).getView();
         ThemedReactContext context = (ThemedReactContext) view.getContext();
-        RCTEventEmitter eventEmitter = context.getJSModule(RCTEventEmitter.class);
-        int viewId = view.getId();
-        eventEmitter.receiveEvent(viewId, REACT_ON_LOAD_EVENT, mapFromResource(resource));
-        eventEmitter.receiveEvent(viewId, REACT_ON_LOAD_END_EVENT, new WritableNativeMap());
+
+        EventDispatcher dispatcher = UIManagerHelper.getEventDispatcherForReactTag(context, view.getId());
+        int surfaceId = UIManagerHelper.getSurfaceId(view);
+
+        if (dispatcher != null) {
+            dispatcher.dispatchEvent(new FastImageLoadEvent(surfaceId, view.getId()));
+            dispatcher.dispatchEvent(new FastImageLoadEndEvent(surfaceId, view.getId()));
+        }
+
         return false;
     }
 }

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
@@ -14,14 +14,19 @@ import androidx.annotation.NonNull;
 
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.RequestManager;
+import com.dylanvann.fastimage.events.FastImageProgressEvent;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.UIManagerHelper;
 import com.facebook.react.uimanager.annotations.ReactProp;
-import com.facebook.react.uimanager.events.RCTEventEmitter;
+import com.facebook.react.uimanager.common.ViewUtil;
+import com.facebook.react.uimanager.events.EventDispatcher;
 import com.facebook.react.views.imagehelper.ResourceDrawableIdHelper;
 
 import java.util.List;
@@ -117,13 +122,17 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
         List<FastImageViewWithUrl> viewsForKey = VIEWS_FOR_URLS.get(key);
         if (viewsForKey != null) {
             for (FastImageViewWithUrl view : viewsForKey) {
-                WritableMap event = new WritableNativeMap();
-                event.putInt("loaded", (int) bytesRead);
-                event.putInt("total", (int) expectedLength);
-                ThemedReactContext context = (ThemedReactContext) view.getContext();
-                RCTEventEmitter eventEmitter = context.getJSModule(RCTEventEmitter.class);
-                int viewId = view.getId();
-                eventEmitter.receiveEvent(viewId, REACT_ON_PROGRESS_EVENT, event);
+                ReactContext context = getReactApplicationContext();
+                EventDispatcher dispatcher = UIManagerHelper.getEventDispatcherForReactTag(context, view.getId());
+                FastImageProgressEvent event = new FastImageProgressEvent(
+                        ViewUtil.NO_SURFACE_ID,
+                        view.getId(),
+                        (int) bytesRead,
+                        (int) expectedLength);
+
+                if (dispatcher != null) {
+                    dispatcher.dispatchEvent(event);
+                }
             }
         }
     }

--- a/android/src/main/java/com/dylanvann/fastimage/events/FastImageErrorEvent.java
+++ b/android/src/main/java/com/dylanvann/fastimage/events/FastImageErrorEvent.java
@@ -1,0 +1,34 @@
+package com.dylanvann.fastimage.events;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.events.Event;
+
+public class FastImageErrorEvent extends Event<FastImageErrorEvent> {
+
+  @Nullable
+  private final ReadableMap mSource;
+
+  public FastImageErrorEvent(int surfaceId, int viewTag, @Nullable ReadableMap source) {
+    super(surfaceId, viewTag);
+    mSource = source;
+  }
+  @NonNull
+  @Override
+  public String getEventName() {
+    return "onFastImageError";
+  }
+
+  @Override
+  protected WritableMap getEventData() {
+    WritableMap eventData = Arguments.createMap();
+    if (mSource != null) {
+      eventData.putString("message", "Invalid source prop:" + mSource);
+    }
+    return eventData;
+  }
+}

--- a/android/src/main/java/com/dylanvann/fastimage/events/FastImageLoadEndEvent.java
+++ b/android/src/main/java/com/dylanvann/fastimage/events/FastImageLoadEndEvent.java
@@ -1,0 +1,19 @@
+package com.dylanvann.fastimage.events;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.react.uimanager.events.Event;
+
+public class FastImageLoadEndEvent extends Event<FastImageLoadEndEvent> {
+
+  public FastImageLoadEndEvent(int surfaceId, int viewTag) {
+    super(surfaceId, viewTag);
+  }
+
+  @NonNull
+  @Override
+  public String getEventName() {
+    return "onFastImageLoadEnd";
+  }
+
+}

--- a/android/src/main/java/com/dylanvann/fastimage/events/FastImageLoadEvent.java
+++ b/android/src/main/java/com/dylanvann/fastimage/events/FastImageLoadEvent.java
@@ -1,0 +1,19 @@
+package com.dylanvann.fastimage.events;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.react.uimanager.events.Event;
+
+public class FastImageLoadEvent extends Event<FastImageLoadEvent> {
+
+  public FastImageLoadEvent(int surfaceId, int viewTag) {
+    super(surfaceId, viewTag);
+  }
+
+  @NonNull
+  @Override
+  public String getEventName() {
+    return "onFastImageLoad";
+  }
+
+}

--- a/android/src/main/java/com/dylanvann/fastimage/events/FastImageLoadStartEvent.java
+++ b/android/src/main/java/com/dylanvann/fastimage/events/FastImageLoadStartEvent.java
@@ -1,0 +1,19 @@
+package com.dylanvann.fastimage.events;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.react.uimanager.events.Event;
+
+public class FastImageLoadStartEvent extends Event<FastImageLoadStartEvent> {
+
+  public FastImageLoadStartEvent(int surfaceId, int viewTag) {
+    super(surfaceId, viewTag);
+  }
+
+  @NonNull
+  @Override
+  public String getEventName() {
+    return "onFastImageLoadStart";
+  }
+
+}

--- a/android/src/main/java/com/dylanvann/fastimage/events/FastImageProgressEvent.java
+++ b/android/src/main/java/com/dylanvann/fastimage/events/FastImageProgressEvent.java
@@ -1,0 +1,34 @@
+package com.dylanvann.fastimage.events;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.events.Event;
+
+public class FastImageProgressEvent extends Event<FastImageProgressEvent> {
+
+  private final int mBytesRead;
+  private final int mExpectedLength;
+
+  public FastImageProgressEvent(int surfaceId, int viewTag, int bytesRead, int expectedLength) {
+    super(surfaceId, viewTag);
+    this.mBytesRead = bytesRead;
+    this.mExpectedLength = expectedLength;
+  }
+
+  @NonNull
+  @Override
+  public String getEventName() {
+    return "onFastImageProgress";
+  }
+
+  @Override
+  protected WritableMap getEventData() {
+    WritableMap eventData = Arguments.createMap();
+    eventData.putInt("loaded", mBytesRead);
+    eventData.putInt("total", mExpectedLength);
+    return eventData;
+  }
+
+}


### PR DESCRIPTION
## The problem

I've been trying `react-native-fast-image` against 0.74 RC with Bridgeless mode and the library doens't work well on Android. The reason is that the library is usign RCTEventEmitter which is deprecated. I'm moving over to use the EventDispatcher.

## Test Plan

| Before (NewArch-Bridgeless) | After (OldArch) | After (NewArch-Bridge) | After (NewArch-Bridgeless) |
| --- | --- | --- | --- |
| ![before](https://github.com/DylanVann/react-native-fast-image/assets/3001957/e9925a1f-4e91-4dc0-8e89-79204b1ebaa9) | ![oldarch](https://github.com/DylanVann/react-native-fast-image/assets/3001957/99097be0-2afb-48e0-8f80-3ee7a93df1b4) | ![newarch](https://github.com/DylanVann/react-native-fast-image/assets/3001957/81383b7b-4ec2-4268-b39f-540e98a88018) | ![bridgeless](https://github.com/DylanVann/react-native-fast-image/assets/3001957/08ffa7b2-ab9c-4c2d-980f-90a2e5806c2f) |


